### PR TITLE
feat: NotificationCenter: accept JSON prop for specifying the notification types

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ return (
     publicKey={YOUR_PROJECT_PUBLIC_KEY}
     network={'devnet'}
     theme={theme}
+    notifications={[
+      { name: 'Welcome message on thread creation', detail: 'Event' },
+      { name: 'Collateral health', detail: 'Below 130%' },
+    ]}
   />
 );
 

--- a/examples/jet/pages/index.tsx
+++ b/examples/jet/pages/index.tsx
@@ -118,6 +118,10 @@ function AuthedHome() {
             publicKey={JET_PUBLIC_KEY}
             theme={theme}
             variables={themeVariables}
+            notifications={[
+              { name: 'Liqudiations', detail: 'Event' },
+              { name: 'Collateral health', detail: 'Below 130%' },
+            ]}
           />
           <WalletButton />
         </div>

--- a/examples/notifications/pages/index.tsx
+++ b/examples/notifications/pages/index.tsx
@@ -53,6 +53,10 @@ function AuthedHome() {
           publicKey={DIALECT_PUBLIC_KEY}
           theme={theme}
           variables={themeVariables}
+          notifications={[
+            { name: 'Welcome message on thread creation', detail: 'Event' },
+            { name: 'Collateral health', detail: 'Below 130%' },
+          ]}
         />
         <WalletButton />
       </div>

--- a/packages/dialect-react-ui/components/Chat/CreateThread.tsx
+++ b/packages/dialect-react-ui/components/Chat/CreateThread.tsx
@@ -36,7 +36,6 @@ export default function CreateThread({
       />
       <div className="h-4" />
       <ValueRow
-        highlighted
         label="Rent Deposit (recoverable)"
         className={cs('w-full mb-4')}
       >

--- a/packages/dialect-react-ui/components/Chat/ThreadSettings.tsx
+++ b/packages/dialect-react-ui/components/Chat/ThreadSettings.tsx
@@ -22,47 +22,52 @@ export default function Settings(props: { toggleSettings: () => void }) {
   return (
     <>
       <div>
-        <ValueRow label="Deposited Rent" className={cs('mb-1')}>
-          0.058 SOL
-        </ValueRow>
-        <Divider />
         {dialectAddress ? (
-          <>
-            <ValueRow label="Thread account" className="mt-1 mb-4">
-              <a
-                target="_blank"
-                href={getExplorerAddress(dialectAddress)}
-                rel="noreferrer"
-              >
-                {display(dialectAddress)}↗
-              </a>
-            </ValueRow>
-            <BigButton
-              className={colors.errorBg}
-              onClick={async () => {
-                await deleteDialect().catch(noop);
-                // TODO: properly wait for the deletion
-                props.toggleSettings();
-                setDialectAddress('');
-              }}
-              heading="Withdraw rent & delete history"
-              description="Events history will be lost forever"
-              icon={<icons.trash />}
-              loading={isDialectDeleting}
-            />
-            {deletionError &&
-              deletionError.type !== 'DISCONNECTED_FROM_CHAIN' && (
-                <p
-                  className={cs(
-                    textStyles.small,
-                    'text-red-500 text-center mt-2'
-                  )}
-                >
-                  {deletionError.message}
+          <ValueRow
+            label={
+              <>
+                <p className={cs(textStyles.small, 'opacity-60')}>
+                  Account address
                 </p>
-              )}
-          </>
+                <p>
+                  <a
+                    target="_blank"
+                    href={getExplorerAddress(dialectAddress)}
+                    rel="noreferrer"
+                  >
+                    {display(dialectAddress)}↗
+                  </a>
+                </p>
+              </>
+            }
+            className="mt-1 mb-4"
+          >
+            <div className="text-right">
+              <p className={cs(textStyles.small, 'opacity-60')}>
+                Deposited Rent
+              </p>
+              <p>0.058 SOL</p>
+            </div>
+          </ValueRow>
         ) : null}
+        <BigButton
+          className={colors.errorBg}
+          onClick={async () => {
+            await deleteDialect().catch(noop);
+            // TODO: properly wait for the deletion
+            props.toggleSettings();
+            setDialectAddress('');
+          }}
+          heading="Withdraw rent & delete history"
+          description="Events history will be lost forever"
+          icon={<icons.trash />}
+          loading={isDialectDeleting}
+        />
+        {deletionError && deletionError.type !== 'DISCONNECTED_FROM_CHAIN' && (
+          <p className={cs(textStyles.small, 'text-red-500 text-center mt-2')}>
+            {deletionError.message}
+          </p>
+        )}
       </div>
     </>
   );

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -101,11 +101,17 @@ function Settings(props: {
     <>
       <div className="mb-3">
         <h2 className={cs(textStyles.h2, 'mb-1')}>Notifications</h2>
-        {props.notifications?.map((type) => (
-          <ValueRow key={type.name} label={type.name} className={cs('mb-1')}>
-            {type.detail}
-          </ValueRow>
-        ))}
+        {props.notifications
+          ? props.notifications.map((type) => (
+              <ValueRow
+                key={type.name}
+                label={type.name}
+                className={cs('mb-1')}
+              >
+                {type.detail}
+              </ValueRow>
+            ))
+          : 'No notification types supplied'}
       </div>
       <div>
         <h2 className={cs(textStyles.h2, 'mb-1')}>Thread Account</h2>

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -64,7 +64,6 @@ function CreateThread() {
         Create notifications thread
       </h1>
       <ValueRow
-        highlighted
         label="Rent Deposit (recoverable)"
         className={cs('w-full mb-4')}
       >
@@ -103,13 +102,7 @@ function Settings(props: {
       <div className="mb-3">
         <h2 className={cs(textStyles.h2, 'mb-1')}>Notifications</h2>
         {props.notifications?.map((type) => (
-          <ValueRow
-            key={type.name}
-            label={type.name}
-            highlighted
-            className={cs('mb-1')}
-            colon={false}
-          >
+          <ValueRow key={type.name} label={type.name} className={cs('mb-1')}>
             {type.detail}
           </ValueRow>
         ))}
@@ -118,22 +111,32 @@ function Settings(props: {
         <h2 className={cs(textStyles.h2, 'mb-1')}>Thread Account</h2>
         {dialectAddress ? (
           <ValueRow
-            label={display(dialectAddress)}
-            highlighted
-            className="mt-1 mb-1"
+            label={
+              <>
+                <p className={cs(textStyles.small, 'opacity-60')}>
+                  Account address
+                </p>
+                <p>
+                  <a
+                    target="_blank"
+                    href={getExplorerAddress(dialectAddress)}
+                    rel="noreferrer"
+                  >
+                    {display(dialectAddress)}↗
+                  </a>
+                </p>
+              </>
+            }
+            className="mt-1 mb-4"
           >
-            <a
-              target="_blank"
-              href={getExplorerAddress(dialectAddress)}
-              rel="noreferrer"
-            >
-              View on Solscan ↗
-            </a>
+            <div className="text-right">
+              <p className={cs(textStyles.small, 'opacity-60')}>
+                Deposited Rent
+              </p>
+              <p>0.058 SOL</p>
+            </div>
           </ValueRow>
         ) : null}
-        <ValueRow label="Deposited Rent" highlighted className={cs('mb-3')}>
-          0.058 SOL
-        </ValueRow>
         {dialectAddress ? (
           <>
             <BigButton

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -15,6 +15,11 @@ import { getExplorerAddress } from '../../utils/getExplorerAddress';
 import IconButton from '../IconButton';
 import { Notification } from './Notification';
 
+export type NotificationType = {
+  name: string;
+  detail: string;
+};
+
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
@@ -85,7 +90,10 @@ function CreateThread() {
   );
 }
 
-function Settings(props: { toggleSettings: () => void }) {
+function Settings(props: {
+  toggleSettings: () => void;
+  notifications: NotificationType[];
+}) {
   const { dialectAddress, deleteDialect, isDialectDeleting, deletionError } =
     useDialect();
   const { colors, textStyles, icons } = useTheme();
@@ -93,30 +101,41 @@ function Settings(props: { toggleSettings: () => void }) {
   return (
     <>
       <div className="mb-3">
-        <p className={cs(textStyles.body, 'mb-1')}>Included event types</p>
-        <ul className={cs(textStyles.bigText, 'list-disc pl-6')}>
-          <li>Welcome message on thread creation</li>
-        </ul>
+        <h2 className={cs(textStyles.h2, 'mb-1')}>Notifications</h2>
+        {props.notifications?.map((type) => (
+          <ValueRow
+            key={type.name}
+            label={type.name}
+            highlighted
+            className={cs('mb-1')}
+            colon={false}
+          >
+            {type.detail}
+          </ValueRow>
+        ))}
       </div>
       <div>
-        <ValueRow label="Deposited Rent" className={cs('mb-1')}>
+        <h2 className={cs(textStyles.h2, 'mb-1')}>Thread Account</h2>
+        {dialectAddress ? (
+          <ValueRow
+            label={display(dialectAddress)}
+            highlighted
+            className="mt-1 mb-1"
+          >
+            <a
+              target="_blank"
+              href={getExplorerAddress(dialectAddress)}
+              rel="noreferrer"
+            >
+              View on Solscan ↗
+            </a>
+          </ValueRow>
+        ) : null}
+        <ValueRow label="Deposited Rent" highlighted className={cs('mb-3')}>
           0.058 SOL
         </ValueRow>
-        <Divider />
         {dialectAddress ? (
           <>
-            <ValueRow
-              label="Notifications thread account"
-              className="mt-1 mb-4"
-            >
-              <a
-                target="_blank"
-                href={getExplorerAddress(dialectAddress)}
-                rel="noreferrer"
-              >
-                {display(dialectAddress)}↗
-              </a>
-            </ValueRow>
             <BigButton
               className={colors.errorBg}
               onClick={async () => {
@@ -147,7 +166,9 @@ function Settings(props: { toggleSettings: () => void }) {
   );
 }
 
-export default function Notifications(): JSX.Element {
+export default function Notifications(props: {
+  notifications?: NotificationType[];
+}): JSX.Element {
   const {
     isWalletConnected,
     isDialectAvailable,
@@ -192,7 +213,12 @@ export default function Notifications(): JSX.Element {
   } else if (!isDialectAvailable) {
     content = <CreateThread />;
   } else if (isSettingsOpen) {
-    content = <Settings toggleSettings={toggleSettings} />;
+    content = (
+      <Settings
+        toggleSettings={toggleSettings}
+        notifications={props.notifications}
+      />
+    );
   } else if (isNoMessages) {
     content = (
       <Centered>

--- a/packages/dialect-react-ui/components/NotificationsButton/index.tsx
+++ b/packages/dialect-react-ui/components/NotificationsButton/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@dialectlabs/react';
 import { Transition } from '@headlessui/react';
 import cs from '../../utils/classNames';
-import Notifications from '../Notifications';
+import Notifications, { NotificationType } from '../Notifications';
 import IconButton from '../IconButton';
 import {
   ThemeProvider,
@@ -27,6 +27,7 @@ type PropTypes = {
   variables?: IncomingThemeVariables;
   bellClassName?: string;
   bellStyle?: object;
+  notifications: NotificationType[];
 };
 
 function useOutsideAlerter(
@@ -110,7 +111,7 @@ function WrappedNotificationsButton(
           // className="w-full h-full bg-white/10"
           // style={{ backdropFilter: 'blur(132px)' }}
         >
-          <Notifications />
+          <Notifications notifications={props?.notifications} />
         </div>
       </Transition>
     </div>

--- a/packages/dialect-react-ui/components/common/ThemeProvider.tsx
+++ b/packages/dialect-react-ui/components/common/ThemeProvider.tsx
@@ -29,6 +29,7 @@ export type ThemeColors =
 
 export type ThemeTextStyles =
   | 'h1'
+  | 'h2'
   | 'body'
   | 'small'
   | 'bigText'
@@ -108,6 +109,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
     },
     textStyles: {
       h1: 'font-inter text-3xl font-bold',
+      h2: 'font-inter text-xl font-bold',
       input: 'font-inter',
       textArea: 'font-inter',
       messageBubble: 'font-inter',
@@ -169,6 +171,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
     },
     textStyles: {
       h1: 'font-inter text-3xl font-bold',
+      h2: 'font-inter text-xl font-bold',
       input: 'font-inter',
       textArea: 'font-inter',
       messageBubble: 'font-inter',

--- a/packages/dialect-react-ui/components/common/index.tsx
+++ b/packages/dialect-react-ui/components/common/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DialectLogo, Spinner as SpinnerIcon } from '../Icon';
+import { DialectLogo } from '../Icon';
 import cs from '../../utils/classNames';
 import { useTheme } from './ThemeProvider';
 
@@ -10,10 +10,8 @@ export function Divider(props: { className?: string }): JSX.Element {
 }
 
 export function ValueRow(props: {
-  label: string;
+  label: string | React.ReactNode;
   children: React.ReactNode;
-  highlighted?: boolean;
-  colon?: boolean;
   className?: string;
 }) {
   const { textStyles, highlighted } = useTheme();
@@ -22,14 +20,11 @@ export function ValueRow(props: {
     <p
       className={cs(
         'flex flex-row justify-between',
-        props.highlighted && highlighted,
+        highlighted,
         props.className
       )}
     >
-      <span className={cs(textStyles.body)}>
-        {props.label}
-        {props.colon ? ':' : ''}
-      </span>
+      <span className={cs(textStyles.body)}>{props.label}</span>
       <span className={cs(textStyles.body)}>{props.children}</span>
     </p>
   );
@@ -81,7 +76,7 @@ export function Button(props: {
   loading?: boolean;
   children: React.ReactNode;
 }): JSX.Element {
-  const { button, buttonLoading, textStyles, colors } = useTheme();
+  const { button, buttonLoading, textStyles } = useTheme();
 
   return (
     <button

--- a/packages/dialect-react-ui/components/common/index.tsx
+++ b/packages/dialect-react-ui/components/common/index.tsx
@@ -13,6 +13,7 @@ export function ValueRow(props: {
   label: string;
   children: React.ReactNode;
   highlighted?: boolean;
+  colon?: boolean;
   className?: string;
 }) {
   const { textStyles, highlighted } = useTheme();
@@ -25,7 +26,10 @@ export function ValueRow(props: {
         props.className
       )}
     >
-      <span className={cs(textStyles.body)}>{props.label}:</span>
+      <span className={cs(textStyles.body)}>
+        {props.label}
+        {props.colon ? ':' : ''}
+      </span>
       <span className={cs(textStyles.body)}>{props.children}</span>
     </p>
   );


### PR DESCRIPTION
e.g.

```jsx
<NotificationsButton
  wallet={wallet}
  network={'localnet'}
  publicKey={DIALECT_PUBLIC_KEY}
  theme={theme}
  variables={themeVariables}
  notifications={[
    {name: 'Liqudiations', detail: 'Event'},
    {name: 'Collateral health', detail: 'Below 130%'}
  ]}
/>
```