### PR TITLE
Fix/Remove flicker on message send

### DIFF
--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add documentation to `README` on how to set up a hot-reloading local development environment.
 - Disabled send message text area and show loader instead of send button when message is sending or waiting approval
 - Show send error message below the text input box in chat
+- Remove flicker on message send
 
 ## [0.1.0] - 2022-02-12
 

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
@@ -45,8 +45,8 @@ export default function Thread() {
       setYouCanWrite(membersContainCurrentKey);
     }
   }, [
-    dialect?.dialect
-  ])
+    dialect?.dialect,
+  ]);
 
   const disableSendButton =
     text.length <= 0 ||

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent, FormEvent, useState } from 'react';
+import React, { KeyboardEvent, FormEvent, useState, useEffect } from 'react';
 import cs from '../../../../../../utils/classNames';
 import { useApi, useDialect } from '@dialectlabs/react';
 import type { ParsedErrorData } from '@dialectlabs/react';
@@ -15,6 +15,7 @@ export default function Thread() {
 
   const [text, setText] = useState<string>('');
   const [error, setError] = useState<ParsedErrorData | null | undefined>();
+  const [youCanWrite, setYouCanWrite] = useState<boolean>(false);
 
   const handleError = (err: ParsedErrorData) => {
     setError(err);
@@ -35,9 +36,18 @@ export default function Thread() {
         .catch(handleError);
     }
   };
-  const youCanWrite = dialect?.dialect.members.some(
-    (m) => m.publicKey.equals(wallet?.publicKey) && m.scopes[1]
-  );
+
+  useEffect(() => {
+    const membersContainCurrentKey = dialect?.dialect.members.some(
+      (m) => m.publicKey.equals(wallet?.publicKey) && m.scopes[1]
+    );
+    if (membersContainCurrentKey) {
+      setYouCanWrite(membersContainCurrentKey);
+    }
+  }, [
+    dialect?.dialect
+  ])
+
   const disableSendButton =
     text.length <= 0 ||
     text.length > 280 ||

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
@@ -39,7 +39,7 @@ export default function Thread() {
 
   useEffect(() => {
     const membersContainCurrentKey = dialect?.dialect.members.some(
-      (m) => m.publicKey.equals(wallet?.publicKey) && m.scopes[1]
+      (m) => m.publicKey.equals(wallet?.publicKey) && m.scopes[1] // is not admin but does have write privilages
     );
     if (membersContainCurrentKey) {
       setYouCanWrite(membersContainCurrentKey);

--- a/packages/dialect-react/components/DialectContext/index.tsx
+++ b/packages/dialect-react/components/DialectContext/index.tsx
@@ -120,6 +120,7 @@ export const DialectProvider = (props: PropsType): JSX.Element => {
 
   const { wallet, program } = useApi();
   const isWalletConnected = connected(wallet);
+  const [messages, setMessages] = React.useState<Message[]>([]);
 
   const {
     data: metadata,
@@ -208,6 +209,18 @@ export const DialectProvider = (props: PropsType): JSX.Element => {
     creationError?.type,
     deletionError?.type,
     fetchError?.type,
+  ]);
+
+  useEffect(() => {
+    if (messages.length > 0) {
+      if (wallet && dialect?.dialect && messages.length !== dialect.dialect.messages.length) {
+        setMessages(dialect.dialect.messages);
+      }
+    } else {
+      setMessages(wallet && dialect?.dialect ? dialect.dialect.messages : []);
+    }
+  }, [
+    dialect?.dialect,
   ]);
 
   const createMetadataWrapper = useCallback(async () => {
@@ -349,7 +362,6 @@ export const DialectProvider = (props: PropsType): JSX.Element => {
     [isWalletConnected, program, dialect, mutateDialect]
   );
 
-  const messages = wallet && dialect?.dialect ? dialect.dialect.messages : [];
   // const messages = mockMessages;
   const isDialectAvailable = Boolean(dialect);
   const isMetadataAvailable = Boolean(metadata);

--- a/packages/dialect-react/components/DialectContext/index.tsx
+++ b/packages/dialect-react/components/DialectContext/index.tsx
@@ -212,15 +212,14 @@ export const DialectProvider = (props: PropsType): JSX.Element => {
   ]);
 
   useEffect(() => {
-    if (messages.length > 0) {
-      if (wallet && dialect?.dialect && messages.length !== dialect.dialect.messages.length) {
-        setMessages(dialect.dialect.messages);
-      }
-    } else {
-      setMessages(wallet && dialect?.dialect ? dialect.dialect.messages : []);
+    const hasNewMessage = wallet && dialect?.dialect && messages.length !== dialect.dialect.messages.length;
+    if (hasNewMessage) {
+      setMessages(dialect.dialect.messages);
     }
   }, [
+    wallet,
     dialect?.dialect,
+    messages.length,
   ]);
 
   const createMetadataWrapper = useCallback(async () => {


### PR DESCRIPTION
Removes the flicker on message send. We were re-rendering all the messages before. Every time a message would send `messages` would be set as `[]` because `dialect` would be undefined.

![flicker-screenshot](https://user-images.githubusercontent.com/91906703/161887129-1ce2a6ac-c91f-46d0-aa2a-93a1a97c9e08.gif)

