### PR TITLE
Fix typing long msg without space will expand whole chat

### DIFF
--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Add documentation to `README` on how to set up a hot-reloading local development environment.
+- Fix for typing a long msg without space expand the entire chat
 
 ## [0.1.0] - 2022-02-12
 

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/MessageInput.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/MessageInput.tsx
@@ -31,16 +31,17 @@ export default function MessageInput({
       <div className="dt-flex dt-flex-col dt-pb-2 dt-mb-2">
         <form onSubmit={onSubmit}>
           <div className="dt-relative">
-            <div className="dt-text-sm dt-break-words dt-py-1 dt-pl-2 dt-pr-11">
+            <div style={{ width: '24rem'}} className="dt-text-sm dt-break-words dt-py-1 dt-pl-2 dt-pr-11">
               {text || 'h'}
             </div>
             <div className="dt-absolute dt-top-0 dt-w-full dt-h-full dt-flex dt-flex-grow dt-items-center">
               <Textarea
+                style={{ width: '29rem'}}
                 value={text}
                 onChange={(e) => setText(e.target.value)}
                 onKeyDown={onEnterPress}
                 placeholder="Write something"
-                className={clsx(textArea, 'dt-resize-none dt-h-full dt-w-full')}
+                className={clsx(textArea, 'dt-resize-none dt-h-full dt-w-full dt-break-all')}
               />
               <ButtonBase
                 className="dt-button dt-absolute dt-inset-y-0 dt--right-2 dt-flex dt-items-center dt-pr-3 disabled:dt-cursor-not-allowed"


### PR DESCRIPTION
When you type a long msg without space for instance when you type a long URL or an address, the msg will expand the whole chat unexpectedly. Use won't be able to see the send button or other msgs.

**Before:**
https://user-images.githubusercontent.com/93460079/161997413-5ee5658e-c68a-4b55-a2ec-b777b1bf64cc.mov

**After:**
https://user-images.githubusercontent.com/93460079/161997539-fcb1fc25-d323-467f-aa14-b5fc66f25f66.mov



 