### PR TITLE
Fix shrinking textbox with spaces

### DIFF
--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/MessageInput.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/MessageInput.tsx
@@ -40,7 +40,7 @@ export default function MessageInput({
         <form onSubmit={onSubmit}>
           <div className="dt-relative">
             <div className="dt-text-sm dt-break-words dt-py-1 dt-pl-2 dt-pr-11">
-              {text || 'h'}
+              {text.trim() || 'h'}
             </div>
             <div className="dt-absolute dt-top-0 dt-w-full dt-h-full dt-flex dt-flex-grow dt-items-center">
               <Textarea


### PR DESCRIPTION
Noticed the text area shrinking when there are only spaces

Before:
![textbox-before](https://user-images.githubusercontent.com/91906703/162106459-dc94430b-17b8-4fd7-a277-e5ca5baeeda9.gif)

After:
![textbox-after](https://user-images.githubusercontent.com/91906703/162106468-2eefa886-adf6-4f9d-9129-49f8e6764116.gif)

