### PR TITLE
fix: missing borders

### DIFF
--- a/packages/dialect-react-ui/index.css
+++ b/packages/dialect-react-ui/index.css
@@ -50,7 +50,7 @@
   border-left-style: solid;
 }
 
-@media (min-width: 640px) {
+@media screen(sm) {
   .sm\:dt-border {
     border-style: solid;
   }
@@ -68,7 +68,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media screen(md) {
   .md\:dt-border {
     border-style: solid;
   }
@@ -86,7 +86,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media screen(lg) {
   .lg\:dt-border {
     border-style: solid;
   }
@@ -104,7 +104,7 @@
   }
 }
 
-@media (min-width: 1280px) {
+@media screen(xl) {
   .xl\:dt-border {
     border-style: solid;
   }
@@ -122,7 +122,7 @@
   }
 }
 
-@media (min-width: 1536px) {
+@media screen(2xl) {
   .\2xl\:dt-border {
     border-style: solid;
   }

--- a/packages/dialect-react-ui/index.css
+++ b/packages/dialect-react-ui/index.css
@@ -32,6 +32,97 @@
   box-sizing: border-box; /* 1 */
 }
 
+/* Since we couldn't use preflight for border, define default border style for every side */
+/* https://github.com/tailwindlabs/tailwindcss/issues/938 */
+.dt-border-t {
+  border-top-style: solid;
+}
+.dt-border-r {
+  border-right-style: solid;
+}
+.dt-border-b {
+  border-bottom-style: solid;
+}
+.dt-border-l {
+  border-left-style: solid;
+}
+
+@media (min-width: 640px) {
+  .sm\:dt-border-t {
+    border-top-style: solid;
+  }
+  .sm\:dt-border-r {
+    border-right-style: solid;
+  }
+  .sm\:dt-border-b {
+    border-bottom-style: solid;
+  }
+  .sm\:dt-border-l {
+    border-left-style: solid;
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:dt-border-t {
+    border-top-style: solid;
+  }
+  .md\:dt-border-r {
+    border-right-style: solid;
+  }
+  .md\:dt-border-b {
+    border-bottom-style: solid;
+  }
+  .md\:dt-border-l {
+    border-left-style: solid;
+  }
+}
+
+@media (min-width: 1024px) {
+  .lg\:dt-border-t {
+    border-top-style: solid;
+  }
+  .lg\:dt-border-r {
+    border-right-style: solid;
+  }
+  .lg\:dt-border-b {
+    border-bottom-style: solid;
+  }
+  .lg\:dt-border-l {
+    border-left-style: solid;
+  }
+}
+
+@media (min-width: 1280px) {
+  .xl\:dt-border-t {
+    border-top-style: solid;
+  }
+  .xl\:dt-border-r {
+    border-right-style: solid;
+  }
+  .xl\:dt-border-b {
+    border-bottom-style: solid;
+  }
+  .xl\:dt-border-l {
+    border-left-style: solid;
+  }
+}
+
+@media (min-width: 1536px) {
+  .\2xl\:dt-border-t {
+    border-top-style: solid;
+  }
+  .\2xl\:dt-border-r {
+    border-right-style: solid;
+  }
+  .\2xl\:dt-border-b {
+    border-bottom-style: solid;
+  }
+  .\2xl\:dt-border-l {
+    border-left-style: solid;
+  }
+}
+
+
 .dialect ::before,
 .dialect ::after {
   --tw-content: '';

--- a/packages/dialect-react-ui/index.css
+++ b/packages/dialect-react-ui/index.css
@@ -34,6 +34,9 @@
 
 /* Since we couldn't use preflight for border, define default border style for every side */
 /* https://github.com/tailwindlabs/tailwindcss/issues/938 */
+.dt-border {
+  border-style: solid;
+}
 .dt-border-t {
   border-top-style: solid;
 }
@@ -48,6 +51,9 @@
 }
 
 @media (min-width: 640px) {
+  .sm\:dt-border {
+    border-style: solid;
+  }
   .sm\:dt-border-t {
     border-top-style: solid;
   }
@@ -63,6 +69,9 @@
 }
 
 @media (min-width: 768px) {
+  .md\:dt-border {
+    border-style: solid;
+  }
   .md\:dt-border-t {
     border-top-style: solid;
   }
@@ -78,6 +87,9 @@
 }
 
 @media (min-width: 1024px) {
+  .lg\:dt-border {
+    border-style: solid;
+  }
   .lg\:dt-border-t {
     border-top-style: solid;
   }
@@ -93,6 +105,9 @@
 }
 
 @media (min-width: 1280px) {
+  .xl\:dt-border {
+    border-style: solid;
+  }
   .xl\:dt-border-t {
     border-top-style: solid;
   }
@@ -108,6 +123,9 @@
 }
 
 @media (min-width: 1536px) {
+  .\2xl\:dt-border {
+    border-style: solid;
+  }
   .\2xl\:dt-border-t {
     border-top-style: solid;
   }


### PR DESCRIPTION
Related to https://github.com/tailwindlabs/tailwindcss/issues/938

If the project is not using the Tailwind lib, they don't have the following preflight borders: 
```css
*,
::before,
::after {
border: 0px solid #e5e7eb;
}
```

Therefore borders are not showing if border-style is not set explicitly.


We also could not use the prefixed preflight since it will override every class because `.dialect *` more specific than `.dt-border-b`
```css
/* Couldn't do so*/
.dialect *,
.dialect ::before,
.dialect ::after {
border: 0px solid #e5e7eb;
}
``` 

So the solution is to set the default border style only for desired side