### PR TITLE
[wip] Fix chat styles (scrollbars, paddings, avatart margin) & add links

### DIFF
--- a/packages/dialect-react-ui/components/Chat/screens/Main/ThreadsList/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/ThreadsList/index.tsx
@@ -19,7 +19,7 @@ const ThreadsList = ({ chatThreads, onThreadClick }: ThreadsListProps) => {
     [chatThreads]
   );
 
-  const { colors, highlighted, textStyles } = useTheme();
+  const { colors, highlighted, textStyles, scrollbar } = useTheme();
 
   if (!chatThreads.length) {
     return (
@@ -30,7 +30,12 @@ const ThreadsList = ({ chatThreads, onThreadClick }: ThreadsListProps) => {
   }
 
   return (
-    <div className="dt-flex dt-flex-1 dt-flex-col dt-space-y-2 dt-py-2 dt-overflow-y-auto">
+    <div
+      className={clsx(
+        'dt-flex dt-flex-1 dt-flex-col dt-space-y-2 dt-py-2 dt-overflow-y-auto',
+        scrollbar
+      )}
+    >
       {isNotSollet && hasEncryptedMessages && (
         <div
           className={clsx(

--- a/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
@@ -33,6 +33,7 @@ const Main = ({ inbox, onModalClose }: MainProps) => {
         <div className="dt-px-2 dt-pt-2 dt-pb-4 dt-flex dt-justify-between dt-border-b dt-border-neutral-900 dt-font-bold">
           Messages
           <div className="dt-flex">
+            {/* TODO: replace with IconButton to be sematic */}
             <div
               className="dt-cursor-pointer dt-inline-flex"
               onClick={() => {

--- a/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
@@ -34,7 +34,7 @@ const Main = ({ inbox, onModalClose }: MainProps) => {
           Messages
           <div className="dt-flex">
             <div
-              className="dt-cursor-pointer"
+              className="dt-cursor-pointer dt-inline-flex"
               onClick={() => {
                 setNewThreadOpen(true);
               }}

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/CreateThreadPage/CreateThread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/CreateThreadPage/CreateThread.tsx
@@ -108,6 +108,7 @@ export default function CreateThread({
   return (
     <div className="dt-flex dt-flex-col dt-flex-1">
       <div className="dt-px-4 dt-pt-2 dt-pb-4 dt-flex dt-justify-between dt-border-b dt-border-neutral-900 dt-font-bold dt-items-center">
+        {/* TODO: replace with IconButton to be sematic */}
         <div
           className="dt-cursor-pointer"
           onClick={() => {

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/MessageInput.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/MessageInput.tsx
@@ -51,7 +51,10 @@ export default function MessageInput({
                 }}
                 onKeyDown={onEnterPress}
                 placeholder="Write something"
-                className={clsx(textArea, 'dt-resize-none dt-h-full dt-w-full')}
+                className={clsx(
+                  textArea,
+                  'dt-resize-none dt-h-full dt-w-full dt-no-scrollbar'
+                )}
                 disabled={inputDisabled}
               />
               <ButtonBase

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
@@ -127,7 +127,7 @@ export default function Thread() {
               <div
                 className={cs(
                   otherMessageBubble,
-                  'dt-max-w-xs dt-flex-row dt-flex-shrink'
+                  'dt-max-w-xs dt-flex-row dt-flex-shrink dt-ml-1'
                 )}
               >
                 <div className={'dt-text-left'}>

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
@@ -12,7 +12,8 @@ export default function Thread() {
   const { isDialectCreating, dialect, messages, sendMessage, sendingMessage } =
     useDialect();
   const { wallet } = useApi();
-  const { messageBubble, otherMessageBubble, textStyles } = useTheme();
+  const { messageBubble, otherMessageBubble, textStyles, scrollbar } =
+    useTheme();
 
   const [text, setText] = useState<string>('');
   const [error, setError] = useState<ParsedErrorData | null | undefined>();
@@ -57,7 +58,13 @@ export default function Thread() {
 
   return (
     <div className="dt-flex dt-flex-col dt-h-full dt-justify-between">
-      <div className="dt-h-full dt-py-2 dt-overflow-y-auto dt-flex dt-flex-col-reverse dt-space-y-2 dt-space-y-reverse dt-justify-start">
+      {/* TODO: fix messages which stretch the entire messaging col */}
+      <div
+        className={cs(
+          'dt-h-full dt-py-2 dt-overflow-y-auto dt-flex dt-flex-col-reverse dt-space-y-2 dt-space-y-reverse dt-justify-start',
+          scrollbar
+        )}
+      >
         {messages.map((message) => {
           const isYou =
             message.owner.toString() === wallet?.publicKey?.toString();
@@ -74,7 +81,7 @@ export default function Thread() {
                   <div className={'dt-items-end'}>
                     <div
                       className={
-                        'dt-break-words dt-text-sm dt-text-right dt-whitespace-pre-wrap'
+                        'dt-break-words dt-whitespace-pre-wrap dt-text-sm dt-text-right'
                       }
                     >
                       <Linkify

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
@@ -1,16 +1,18 @@
 import React, { KeyboardEvent, FormEvent, useState, useEffect } from 'react';
-import cs from '../../../../../../utils/classNames';
+import Linkify from 'react-linkify';
 import { useApi, useDialect, formatTimestamp } from '@dialectlabs/react';
 import type { ParsedErrorData } from '@dialectlabs/react';
+import { A } from '../../../../../common/preflighted';
 import { useTheme } from '../../../../../common/ThemeProvider';
-import MessageInput from './MessageInput';
+import cs from '../../../../../../utils/classNames';
 import Avatar from '../../../../../Avatar';
+import MessageInput from './MessageInput';
 
 export default function Thread() {
   const { isDialectCreating, dialect, messages, sendMessage, sendingMessage } =
     useDialect();
   const { wallet } = useApi();
-  const { messageBubble, otherMessageBubble } = useTheme();
+  const { messageBubble, otherMessageBubble, textStyles } = useTheme();
 
   const [text, setText] = useState<string>('');
   const [error, setError] = useState<ParsedErrorData | null | undefined>();
@@ -43,9 +45,7 @@ export default function Thread() {
     if (membersContainCurrentKey) {
       setYouCanWrite(membersContainCurrentKey);
     }
-  }, [
-    dialect?.dialect,
-  ]);
+  }, [dialect?.dialect]);
 
   const disableSendButton =
     text.length <= 0 ||
@@ -72,8 +72,31 @@ export default function Thread() {
               >
                 <div className={cs(messageBubble, 'dt-max-w-full dt-flex-row')}>
                   <div className={'dt-items-end'}>
-                    <div className={'dt-break-words dt-text-sm dt-text-right'}>
-                      {message.text}
+                    <div
+                      className={
+                        'dt-break-words dt-text-sm dt-text-right dt-whitespace-pre-wrap'
+                      }
+                    >
+                      <Linkify
+                        componentDecorator={(
+                          decoratedHref: string,
+                          decoratedText: string,
+                          key: number
+                        ) => (
+                          <A
+                            target="blank"
+                            className={textStyles.link}
+                            href={decoratedHref}
+                            key={key}
+                          >
+                            {decoratedText.length > 32
+                              ? decoratedText.slice(0, 32) + '...'
+                              : decoratedText}
+                          </A>
+                        )}
+                      >
+                        {message.text}
+                      </Linkify>
                     </div>
                     <div className={''}>
                       <div className={'dt-opacity-50 dt-text-xs'}>
@@ -101,8 +124,31 @@ export default function Thread() {
                 )}
               >
                 <div className={'dt-text-left'}>
-                  <div className={'dt-text-sm dt-break-words'}>
-                    {message.text}
+                  <div
+                    className={
+                      'dt-text-sm dt-break-words dt-whitespace-pre-wrap'
+                    }
+                  >
+                    <Linkify
+                      componentDecorator={(
+                        decoratedHref: string,
+                        decoratedText: string,
+                        key: number
+                      ) => (
+                        <A
+                          target="blank"
+                          className={textStyles.link}
+                          href={decoratedHref}
+                          key={key}
+                        >
+                          {decoratedText.length > 32
+                            ? decoratedText.slice(0, 32) + '...'
+                            : decoratedText}
+                        </A>
+                      )}
+                    >
+                      {message.text}
+                    </Linkify>
                   </div>
                   <div className={'dt-items-end'}>
                     <div className={'dt-opacity-50 dt-text-xs dt-text-right'}>

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
@@ -99,7 +99,7 @@ const ThreadPage = ({
           )}
         </div>
       </div>
-      <div className="dt-flex-1 dt-px-2 dt-overflow-y-scroll">
+      <div className="dt-flex-1 dt-px-2 dt-overflow-y-auto">
         {settingsOpen ? <Settings /> : <Thread />}
       </div>
     </div>

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
@@ -47,6 +47,7 @@ const ThreadPage = ({
     }
     return (
       <div className="dt-hidden md:dt-flex dt-flex-1 dt-justify-center dt-items-center">
+        {/* TODO: replace with Button to be sematic */}
         <div
           className="dt-flex dt-cursor-pointer dt-opacity-30"
           onClick={onNewThreadClick}
@@ -61,6 +62,7 @@ const ThreadPage = ({
   return (
     <div className="dt-flex dt-flex-col dt-flex-1">
       <div className="dt-px-4 dt-py-1 dt-flex dt-justify-between dt-border-b dt-border-neutral-900 dt-items-center">
+        {/* TODO: replace with IconButton to be sematic */}
         <div
           className={clsx('dt-cursor-pointer')}
           onClick={() => {
@@ -84,6 +86,7 @@ const ThreadPage = ({
           )}
         </div>
         <div className="dt-flex">
+          {/* TODO: replace with IconButton to be sematic */}
           <div
             className={clsx('dt-cursor-pointer', {
               'dt-invisible': settingsOpen,

--- a/packages/dialect-react-ui/components/Notifications/Notification.tsx
+++ b/packages/dialect-react-ui/components/Notifications/Notification.tsx
@@ -30,7 +30,12 @@ export const Notification = ({ message, timestamp }: Props) => {
       )}
     >
       <div className="dt-flex-1 dt-mb-2">
-        <P className={cs(textStyles.body, 'dt-font-medium dt-text-base')}>
+        <P
+          className={cs(
+            textStyles.body,
+            'dt-break-words dt-whitespace-pre-wrap dt-font-medium dt-text-base'
+          )}
+        >
           <Linkify
             componentDecorator={(
               decoratedHref: string,

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -319,7 +319,7 @@ export default function Notifications(props: {
     [isSettingsOpen, setSettingsOpen]
   );
 
-  const { colors, modal, icons, notificationsDivider } = useTheme();
+  const { colors, modal, icons, notificationsDivider, scrollbar } = useTheme();
 
   let content: JSX.Element;
 
@@ -395,7 +395,12 @@ export default function Notifications(props: {
           onModalClose={props.onModalClose}
           toggleSettings={toggleSettings}
         />
-        <div className="dt-h-full dt-py-2 dt-px-4 dt-overflow-y-auto dt-no-scrollbar">
+        <div
+          className={cs(
+            'dt-h-full dt-py-2 dt-px-4 dt-overflow-y-auto',
+            scrollbar
+          )}
+        >
           {content}
         </div>
         <Footer />

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -395,7 +395,7 @@ export default function Notifications(props: {
           onModalClose={props.onModalClose}
           toggleSettings={toggleSettings}
         />
-        <div className="dt-h-full dt-py-2 dt-px-4 dt-overflow-y-scroll dt-no-scrollbar">
+        <div className="dt-h-full dt-py-2 dt-px-4 dt-overflow-y-auto dt-no-scrollbar">
           {content}
         </div>
         <Footer />

--- a/packages/dialect-react-ui/components/common/ThemeProvider.tsx
+++ b/packages/dialect-react-ui/components/common/ThemeProvider.tsx
@@ -97,6 +97,7 @@ export type IncomingThemeValues = {
   bigButtonLoading?: string;
   divider?: string;
   highlighted?: string;
+  scrollbar?: string;
 };
 
 export type IncomingThemeVariables = Partial<
@@ -180,7 +181,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
     notificationsDivider: 'dt-hidden',
     modalWrapper:
       'dt-fixed dt-z-50 dt-top-0 dt-w-full dt-h-full dt-right-0 sm:dt-absolute sm:dt-top-16 sm:dt-w-[30rem] sm:dt-h-[40rem]',
-    modal: 'dt-rounded-none sm:dt-rounded-3xl',
+    modal: 'dt-rounded-none dt-shadow-md sm:dt-rounded-3xl',
     button:
       'dt-bg-black dt-text-white dt-border dt-border-black hover:dt-opacity-60',
     secondaryButton:
@@ -196,6 +197,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
       'dt-min-h-[42px] dt-border dt-border-black dt-opacity-20 dt-bg-transparent',
     divider: 'dt-h-px dt-opacity-10 dt-bg-current',
     highlighted: 'dt-px-4 dt-py-3 dt-rounded-lg',
+    scrollbar: 'dt-light-scrollbar',
   },
   dark: {
     colors: {
@@ -279,6 +281,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
       'dt-min-h-[42px] dt-border dt-border-white dt-opacity-20 dt-bg-transparent',
     divider: 'dt-h-px dt-opacity-30 dt-bg-current',
     highlighted: 'dt-px-4 dt-py-3 dt-rounded-lg',
+    scrollbar: 'dt-dark-scrollbar',
   },
 };
 

--- a/packages/dialect-react-ui/index.css
+++ b/packages/dialect-react-ui/index.css
@@ -140,7 +140,6 @@
   }
 }
 
-
 .dialect ::before,
 .dialect ::after {
   --tw-content: '';
@@ -470,6 +469,39 @@
   height: auto;
 }
 
+.dialect *::-webkit-scrollbar {
+  width: 12px; /* Mostly for vertical scrollbars */
+  height: 12px; /* Mostly for horizontal scrollbars */
+}
+.dialect *::-webkit-scrollbar-track {
+  /* Background */
+  background: transparent;
+}
+.dt-light-scrollbar {
+  /* Firefox: Foreground, Background */
+  scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+}
+.dt-light-scrollbar::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  /* Foreground */
+  background: transparent;
+  /* hack to add visual margin to thumb https://stackoverflow.com/questions/29866759/how-do-i-add-a-margin-to-a-css-webkit-scrollbar */
+  box-shadow: inset 0 0 10px 10px rgba(0, 0, 0, 0.3);
+  border: solid 3px transparent;
+}
+.dt-dark-scrollbar {
+  /* Firefox: Foreground, Background */
+  scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+}
+.dt-dark-scrollbar::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  /* Foreground */
+  background: transparent;
+  /* hack to add visual margin to thumb https://stackoverflow.com/questions/29866759/how-do-i-add-a-margin-to-a-css-webkit-scrollbar */
+  box-shadow: inset 0 0 10px 10px rgba(255, 255, 255, 0.3);
+  border: solid 3px transparent;
+}
+
 /* Hide scrollbar for Chrome, Safari and Opera */
 .dt-no-scrollbar::-webkit-scrollbar {
   display: none;
@@ -477,8 +509,8 @@
 
 /* Hide scrollbar for IE, Edge and Firefox */
 .dt-no-scrollbar {
-  -ms-overflow-style: none;  /* IE and Edge */
-  scrollbar-width: none;  /* Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
 }
 
 @tailwind components;


### PR DESCRIPTION
## Context
It's actually a OS-specific setting how to show scrollbars when not scrolling. Defaults to "only while scrolling" on macOS, and to "always" on windows, linux.

These PR style scrollbars to make them more elegant if shown (`scrollbar` key introduced in theme variables). It also hides scrollbars from textarea completly, since textarrea resizes with new text added.

### before:
<img width="1104" alt="Screenshot 2022-04-14 at 13 32 49" src="https://user-images.githubusercontent.com/2504771/163363369-5652b9cb-0005-4c17-96a1-48401ff1b860.png">

### after:
<img width="1063" alt="Screenshot 2022-04-14 at 13 37 43" src="https://user-images.githubusercontent.com/2504771/163363356-07f601f3-6820-41ea-a7fd-d7ce458558bd.png">

