### PR TITLE
Fix chat styles (scrollbars, paddings, avatart margin) & add links

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
-"trailingComma": "es5",
-"tabWidth": 2,
-"semi": true,
-"singleQuote": true
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true
 }

--- a/examples/jet/pages/index.tsx
+++ b/examples/jet/pages/index.tsx
@@ -34,6 +34,7 @@ export const themeVariables: IncomingThemeVariables = {
       bigText: 'text-base font-medium leading-snug',
       header: 'font-poppins text-lg',
       buttonText: 'text-xs uppercase tracking-[1.5px] text-[#E6EBF3]',
+      // TODO: Deprecate BigButton
       bigButtonText: 'text-xs uppercase tracking-[1.5px]',
       bigButtonSubtle: 'text-xs uppercase tracking-[1.5px]',
     },
@@ -47,10 +48,11 @@ export const themeVariables: IncomingThemeVariables = {
     modal: 'rounded-3xl jet-shadow',
     button: 'bg-gradient text-[#E6EBF3] hover:opacity-60',
     buttonLoading: 'bg-gradient min-h-[32px] opacity-20',
-    bigButton: 'text-white hover:opacity-60',
-    bigButtonLoading: 'text-white min-h-[32px] opacity-20',
     divider: 'h-[4px] rounded-lg bg-gradient-to-b from-[#C3CADE] to-[#F8F9FB]',
     highlighted: 'px-2 py-1 rounded-lg',
+    // TODO: Deprecate BigButton
+    bigButton: 'text-white hover:opacity-60',
+    bigButtonLoading: 'text-white min-h-[32px] opacity-20',
   },
   dark: {
     colors: {
@@ -70,6 +72,7 @@ export const themeVariables: IncomingThemeVariables = {
       bigText: 'text-base font-medium leading-snug',
       header: 'font-poppins text-lg',
       buttonText: 'text-xs uppercase tracking-[1.5px] text-[#444]',
+      // TODO: Deprecate BigButton
       bigButtonText: 'text-xs uppercase tracking-[1.5px]',
       bigButtonSubtle: 'text-xs uppercase tracking-[1.5px]',
     },
@@ -83,10 +86,11 @@ export const themeVariables: IncomingThemeVariables = {
     modal: 'rounded-3xl jet-shadow',
     button: 'bg-gradient text-[#E6EBF3] hover:opacity-60',
     buttonLoading: 'bg-gradient min-h-[32px] opacity-20',
-    bigButton: 'text-white hover:opacity-60',
-    bigButtonLoading: 'text-white min-h-[32px] opacity-20',
     divider: 'h-[4px] rounded-lg bg-gradient-to-b from-[#3C3C3C] to-[#505050]',
     highlighted: 'px-2 py-1 rounded-lg',
+    // TODO: Deprecate BigButton
+    bigButton: 'text-white hover:opacity-60',
+    bigButtonLoading: 'text-white min-h-[32px] opacity-20',
   },
 };
 

--- a/packages/dialect-react-ui/components/Chat/screens/Main/ThreadsList/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/ThreadsList/index.tsx
@@ -19,7 +19,7 @@ const ThreadsList = ({ chatThreads, onThreadClick }: ThreadsListProps) => {
     [chatThreads]
   );
 
-  const { colors, highlighted, textStyles } = useTheme();
+  const { colors, highlighted, textStyles, scrollbar } = useTheme();
 
   if (!chatThreads.length) {
     return (
@@ -30,7 +30,12 @@ const ThreadsList = ({ chatThreads, onThreadClick }: ThreadsListProps) => {
   }
 
   return (
-    <div className="dt-flex dt-flex-1 dt-flex-col dt-space-y-2 dt-py-2 dt-overflow-y-auto">
+    <div
+      className={clsx(
+        'dt-flex dt-flex-1 dt-flex-col dt-space-y-2 dt-py-2 dt-overflow-y-auto',
+        scrollbar
+      )}
+    >
       {isNotSollet && hasEncryptedMessages && (
         <div
           className={clsx(

--- a/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
@@ -33,6 +33,7 @@ const Main = ({ inbox, onModalClose }: MainProps) => {
         <div className="dt-px-2 dt-pt-2 dt-pb-4 dt-flex dt-justify-between dt-border-b dt-border-neutral-900 dt-font-bold">
           Messages
           <div className="dt-flex">
+            {/* TODO: replace with IconButton to be sematic */}
             <div
               className="dt-cursor-pointer dt-inline-flex"
               onClick={() => {

--- a/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
@@ -34,7 +34,7 @@ const Main = ({ inbox, onModalClose }: MainProps) => {
           Messages
           <div className="dt-flex">
             <div
-              className="dt-cursor-pointer"
+              className="dt-cursor-pointer dt-inline-flex"
               onClick={() => {
                 setNewThreadOpen(true);
               }}

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/CreateThreadPage/CreateThread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/CreateThreadPage/CreateThread.tsx
@@ -108,6 +108,7 @@ export default function CreateThread({
   return (
     <div className="dt-flex dt-flex-col dt-flex-1">
       <div className="dt-px-4 dt-pt-2 dt-pb-4 dt-flex dt-justify-between dt-border-b dt-border-neutral-900 dt-font-bold dt-items-center">
+        {/* TODO: replace with IconButton to be sematic */}
         <div
           className="dt-cursor-pointer"
           onClick={() => {

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/MessageInput.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/MessageInput.tsx
@@ -51,7 +51,10 @@ export default function MessageInput({
                 }}
                 onKeyDown={onEnterPress}
                 placeholder="Write something"
-                className={clsx(textArea, 'dt-resize-none dt-h-full dt-w-full')}
+                className={clsx(
+                  textArea,
+                  'dt-resize-none dt-h-full dt-w-full dt-no-scrollbar'
+                )}
                 disabled={inputDisabled}
               />
               <ButtonBase

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Settings.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Settings.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { display } from '@dialectlabs/web3';
 import { useDialect } from '@dialectlabs/react';
 import clsx from 'clsx';
+import { getExplorerAddress } from '../../../../../../utils/getExplorerAddress';
 import { A, P } from '../../../../../common/preflighted';
 import { useTheme } from '../../../../../common/ThemeProvider';
-import { BigButton, ValueRow } from '../../../../../common';
-import { getExplorerAddress } from '../../../../../../utils/getExplorerAddress';
+import { Button, ValueRow } from '../../../../../common';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
@@ -22,7 +22,8 @@ const Settings = ({ onCloseRequest }: SettingsProps) => {
     deletionError,
     setDialectAddress,
   } = useDialect();
-  const { colors, textStyles, icons } = useTheme();
+  const { textStyles, secondaryDangerButton, secondaryDangerButtonLoading } =
+    useTheme();
 
   return (
     <>
@@ -55,19 +56,20 @@ const Settings = ({ onCloseRequest }: SettingsProps) => {
             </div>
           </ValueRow>
         ) : null}
-        <BigButton
-          className={colors.errorBg}
+        <Button
+          className="dt-w-full"
+          defaultStyle={secondaryDangerButton}
+          loadingStyle={secondaryDangerButtonLoading}
           onClick={async () => {
             await deleteDialect().catch(noop);
             // TODO: properly wait for the deletion
             onCloseRequest?.();
             setDialectAddress('');
           }}
-          heading="Withdraw rent & delete history"
-          description="Events history will be lost forever"
-          icon={<icons.trash />}
           loading={isDialectDeleting}
-        />
+        >
+          Withdraw rent & delete history
+        </Button>
         {deletionError && deletionError.type !== 'DISCONNECTED_FROM_CHAIN' && (
           <P
             className={clsx(

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
@@ -127,7 +127,7 @@ export default function Thread() {
               <div
                 className={cs(
                   otherMessageBubble,
-                  'dt-max-w-xs dt-flex-row dt-flex-shrink'
+                  'dt-max-w-xs dt-flex-row dt-flex-shrink dt-ml-1'
                 )}
               >
                 <div className={'dt-text-left'}>

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
@@ -12,7 +12,8 @@ export default function Thread() {
   const { isDialectCreating, dialect, messages, sendMessage, sendingMessage } =
     useDialect();
   const { wallet } = useApi();
-  const { messageBubble, otherMessageBubble, textStyles } = useTheme();
+  const { messageBubble, otherMessageBubble, textStyles, scrollbar } =
+    useTheme();
 
   const [text, setText] = useState<string>('');
   const [error, setError] = useState<ParsedErrorData | null | undefined>();
@@ -57,7 +58,13 @@ export default function Thread() {
 
   return (
     <div className="dt-flex dt-flex-col dt-h-full dt-justify-between">
-      <div className="dt-h-full dt-py-2 dt-overflow-y-auto dt-flex dt-flex-col-reverse dt-space-y-2 dt-space-y-reverse dt-justify-start">
+      {/* TODO: fix messages which stretch the entire messaging col */}
+      <div
+        className={cs(
+          'dt-h-full dt-py-2 dt-overflow-y-auto dt-flex dt-flex-col-reverse dt-space-y-2 dt-space-y-reverse dt-justify-start',
+          scrollbar
+        )}
+      >
         {messages.map((message) => {
           const isYou =
             message.owner.toString() === wallet?.publicKey?.toString();
@@ -74,7 +81,7 @@ export default function Thread() {
                   <div className={'dt-items-end'}>
                     <div
                       className={
-                        'dt-break-words dt-text-sm dt-text-right dt-whitespace-pre-wrap'
+                        'dt-break-words dt-whitespace-pre-wrap dt-text-sm dt-text-right'
                       }
                     >
                       <Linkify

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
@@ -1,8 +1,7 @@
 import React, { KeyboardEvent, FormEvent, useState, useEffect } from 'react';
-import Linkify from 'react-linkify';
 import { useApi, useDialect, formatTimestamp } from '@dialectlabs/react';
 import type { ParsedErrorData } from '@dialectlabs/react';
-import { A } from '../../../../../common/preflighted';
+import { LinkifiedText } from '../../../../../common';
 import { useTheme } from '../../../../../common/ThemeProvider';
 import cs from '../../../../../../utils/classNames';
 import Avatar from '../../../../../Avatar';
@@ -12,8 +11,7 @@ export default function Thread() {
   const { isDialectCreating, dialect, messages, sendMessage, sendingMessage } =
     useDialect();
   const { wallet } = useApi();
-  const { messageBubble, otherMessageBubble, textStyles, scrollbar } =
-    useTheme();
+  const { messageBubble, otherMessageBubble, scrollbar } = useTheme();
 
   const [text, setText] = useState<string>('');
   const [error, setError] = useState<ParsedErrorData | null | undefined>();
@@ -84,26 +82,7 @@ export default function Thread() {
                         'dt-break-words dt-whitespace-pre-wrap dt-text-sm dt-text-right'
                       }
                     >
-                      <Linkify
-                        componentDecorator={(
-                          decoratedHref: string,
-                          decoratedText: string,
-                          key: number
-                        ) => (
-                          <A
-                            target="blank"
-                            className={textStyles.link}
-                            href={decoratedHref}
-                            key={key}
-                          >
-                            {decoratedText.length > 32
-                              ? decoratedText.slice(0, 32) + '...'
-                              : decoratedText}
-                          </A>
-                        )}
-                      >
-                        {message.text}
-                      </Linkify>
+                      <LinkifiedText>{message.text}</LinkifiedText>
                     </div>
                     <div className={''}>
                       <div className={'dt-opacity-50 dt-text-xs'}>
@@ -136,26 +115,7 @@ export default function Thread() {
                       'dt-text-sm dt-break-words dt-whitespace-pre-wrap'
                     }
                   >
-                    <Linkify
-                      componentDecorator={(
-                        decoratedHref: string,
-                        decoratedText: string,
-                        key: number
-                      ) => (
-                        <A
-                          target="blank"
-                          className={textStyles.link}
-                          href={decoratedHref}
-                          key={key}
-                        >
-                          {decoratedText.length > 32
-                            ? decoratedText.slice(0, 32) + '...'
-                            : decoratedText}
-                        </A>
-                      )}
-                    >
-                      {message.text}
-                    </Linkify>
+                    <LinkifiedText>{message.text}</LinkifiedText>
                   </div>
                   <div className={'dt-items-end'}>
                     <div className={'dt-opacity-50 dt-text-xs dt-text-right'}>

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/Thread.tsx
@@ -1,16 +1,18 @@
 import React, { KeyboardEvent, FormEvent, useState, useEffect } from 'react';
-import cs from '../../../../../../utils/classNames';
+import Linkify from 'react-linkify';
 import { useApi, useDialect, formatTimestamp } from '@dialectlabs/react';
 import type { ParsedErrorData } from '@dialectlabs/react';
+import { A } from '../../../../../common/preflighted';
 import { useTheme } from '../../../../../common/ThemeProvider';
-import MessageInput from './MessageInput';
+import cs from '../../../../../../utils/classNames';
 import Avatar from '../../../../../Avatar';
+import MessageInput from './MessageInput';
 
 export default function Thread() {
   const { isDialectCreating, dialect, messages, sendMessage, sendingMessage } =
     useDialect();
   const { wallet } = useApi();
-  const { messageBubble, otherMessageBubble } = useTheme();
+  const { messageBubble, otherMessageBubble, textStyles } = useTheme();
 
   const [text, setText] = useState<string>('');
   const [error, setError] = useState<ParsedErrorData | null | undefined>();
@@ -43,9 +45,7 @@ export default function Thread() {
     if (membersContainCurrentKey) {
       setYouCanWrite(membersContainCurrentKey);
     }
-  }, [
-    dialect?.dialect,
-  ]);
+  }, [dialect?.dialect]);
 
   const disableSendButton =
     text.length <= 0 ||
@@ -72,8 +72,31 @@ export default function Thread() {
               >
                 <div className={cs(messageBubble, 'dt-max-w-full dt-flex-row')}>
                   <div className={'dt-items-end'}>
-                    <div className={'dt-break-words dt-text-sm dt-text-right'}>
-                      {message.text}
+                    <div
+                      className={
+                        'dt-break-words dt-text-sm dt-text-right dt-whitespace-pre-wrap'
+                      }
+                    >
+                      <Linkify
+                        componentDecorator={(
+                          decoratedHref: string,
+                          decoratedText: string,
+                          key: number
+                        ) => (
+                          <A
+                            target="blank"
+                            className={textStyles.link}
+                            href={decoratedHref}
+                            key={key}
+                          >
+                            {decoratedText.length > 32
+                              ? decoratedText.slice(0, 32) + '...'
+                              : decoratedText}
+                          </A>
+                        )}
+                      >
+                        {message.text}
+                      </Linkify>
                     </div>
                     <div className={''}>
                       <div className={'dt-opacity-50 dt-text-xs'}>
@@ -101,8 +124,31 @@ export default function Thread() {
                 )}
               >
                 <div className={'dt-text-left'}>
-                  <div className={'dt-text-sm dt-break-words'}>
-                    {message.text}
+                  <div
+                    className={
+                      'dt-text-sm dt-break-words dt-whitespace-pre-wrap'
+                    }
+                  >
+                    <Linkify
+                      componentDecorator={(
+                        decoratedHref: string,
+                        decoratedText: string,
+                        key: number
+                      ) => (
+                        <A
+                          target="blank"
+                          className={textStyles.link}
+                          href={decoratedHref}
+                          key={key}
+                        >
+                          {decoratedText.length > 32
+                            ? decoratedText.slice(0, 32) + '...'
+                            : decoratedText}
+                        </A>
+                      )}
+                    >
+                      {message.text}
+                    </Linkify>
                   </div>
                   <div className={'dt-items-end'}>
                     <div className={'dt-opacity-50 dt-text-xs dt-text-right'}>

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
@@ -99,7 +99,7 @@ const ThreadPage = ({
           )}
         </div>
       </div>
-      <div className="dt-flex-1 dt-px-2 dt-overflow-y-scroll">
+      <div className="dt-flex-1 dt-px-2 dt-overflow-y-auto">
         {settingsOpen ? <Settings /> : <Thread />}
       </div>
     </div>

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
@@ -47,6 +47,7 @@ const ThreadPage = ({
     }
     return (
       <div className="dt-hidden md:dt-flex dt-flex-1 dt-justify-center dt-items-center">
+        {/* TODO: replace with Button to be sematic */}
         <div
           className="dt-flex dt-cursor-pointer dt-opacity-30"
           onClick={onNewThreadClick}
@@ -61,6 +62,7 @@ const ThreadPage = ({
   return (
     <div className="dt-flex dt-flex-col dt-flex-1">
       <div className="dt-px-4 dt-py-1 dt-flex dt-justify-between dt-border-b dt-border-neutral-900 dt-items-center">
+        {/* TODO: replace with IconButton to be sematic */}
         <div
           className={clsx('dt-cursor-pointer')}
           onClick={() => {
@@ -84,6 +86,7 @@ const ThreadPage = ({
           )}
         </div>
         <div className="dt-flex">
+          {/* TODO: replace with IconButton to be sematic */}
           <div
             className={clsx('dt-cursor-pointer', {
               'dt-invisible': settingsOpen,

--- a/packages/dialect-react-ui/components/Notifications/EmailForm.tsx
+++ b/packages/dialect-react-ui/components/Notifications/EmailForm.tsx
@@ -31,7 +31,9 @@ export function EmailForm() {
     outlinedInput,
     colors,
     secondaryButton,
+    secondaryButtonLoading,
     secondaryDangerButton,
+    secondaryDangerButtonLoading,
     highlighted,
   } = useTheme();
 
@@ -152,6 +154,7 @@ export function EmailForm() {
               <div className="dt-flex dt-flex-row dt-space-x-2">
                 <Button
                   defaultStyle={secondaryButton}
+                  loadingStyle={secondaryButtonLoading}
                   className="dt-basis-1/2"
                   onClick={() => setEmailEditing(false)}
                 >
@@ -191,6 +194,7 @@ export function EmailForm() {
                 <Button
                   className="dt-basis-1/2"
                   defaultStyle={secondaryDangerButton}
+                  loadingStyle={secondaryDangerButtonLoading}
                   onClick={deleteEmail}
                   loading={isDeletingAddress}
                 >

--- a/packages/dialect-react-ui/components/Notifications/Notification.tsx
+++ b/packages/dialect-react-ui/components/Notifications/Notification.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import Linkify from 'react-linkify';
 import cs from '../../utils/classNames';
-import { A, P } from '../common/preflighted';
+import { LinkifiedText } from '../common';
+import { P } from '../common/preflighted';
 import { useTheme } from '../common/ThemeProvider';
 
 type Props = {
@@ -36,26 +36,7 @@ export const Notification = ({ message, timestamp }: Props) => {
             'dt-break-words dt-whitespace-pre-wrap dt-font-medium dt-text-base'
           )}
         >
-          <Linkify
-            componentDecorator={(
-              decoratedHref: string,
-              decoratedText: string,
-              key: number
-            ) => (
-              <A
-                target="blank"
-                className={textStyles.link}
-                href={decoratedHref}
-                key={key}
-              >
-                {decoratedText.length > 32
-                  ? decoratedText.slice(0, 32) + '...'
-                  : decoratedText}
-              </A>
-            )}
-          >
-            {message}
-          </Linkify>
+          <LinkifiedText>{message}</LinkifiedText>
         </P>
       </div>
       <div className={notificationTimestamp}>

--- a/packages/dialect-react-ui/components/Notifications/Notification.tsx
+++ b/packages/dialect-react-ui/components/Notifications/Notification.tsx
@@ -30,7 +30,12 @@ export const Notification = ({ message, timestamp }: Props) => {
       )}
     >
       <div className="dt-flex-1 dt-mb-2">
-        <P className={cs(textStyles.body, 'dt-font-medium dt-text-base')}>
+        <P
+          className={cs(
+            textStyles.body,
+            'dt-break-words dt-whitespace-pre-wrap dt-font-medium dt-text-base'
+          )}
+        >
           <Linkify
             componentDecorator={(
               decoratedHref: string,

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -319,7 +319,7 @@ export default function Notifications(props: {
     [isSettingsOpen, setSettingsOpen]
   );
 
-  const { colors, modal, icons, notificationsDivider } = useTheme();
+  const { colors, modal, icons, notificationsDivider, scrollbar } = useTheme();
 
   let content: JSX.Element;
 
@@ -395,7 +395,12 @@ export default function Notifications(props: {
           onModalClose={props.onModalClose}
           toggleSettings={toggleSettings}
         />
-        <div className="dt-h-full dt-py-2 dt-px-4 dt-overflow-y-auto dt-no-scrollbar">
+        <div
+          className={cs(
+            'dt-h-full dt-py-2 dt-px-4 dt-overflow-y-auto',
+            scrollbar
+          )}
+        >
           {content}
         </div>
         <Footer />

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -95,7 +95,8 @@ function Wallet(props: { onThreadDelete?: () => void }) {
     deletionError,
     creationError,
   } = useDialect();
-  const { textStyles, secondaryDangerButton } = useTheme();
+  const { textStyles, secondaryDangerButton, secondaryDangerButtonLoading } =
+    useTheme();
   const { balance } = useBalance();
 
   if (isDialectAvailable) {
@@ -137,6 +138,7 @@ function Wallet(props: { onThreadDelete?: () => void }) {
             <Button
               className="dt-w-full"
               defaultStyle={secondaryDangerButton}
+              loadingStyle={secondaryDangerButtonLoading}
               onClick={async () => {
                 await deleteDialect().catch(noop);
                 // TODO: properly wait for the deletion

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -395,7 +395,7 @@ export default function Notifications(props: {
           onModalClose={props.onModalClose}
           toggleSettings={toggleSettings}
         />
-        <div className="dt-h-full dt-py-2 dt-px-4 dt-overflow-y-scroll dt-no-scrollbar">
+        <div className="dt-h-full dt-py-2 dt-px-4 dt-overflow-y-auto dt-no-scrollbar">
           {content}
         </div>
         <Footer />

--- a/packages/dialect-react-ui/components/common/LinkifiedText.tsx
+++ b/packages/dialect-react-ui/components/common/LinkifiedText.tsx
@@ -1,0 +1,37 @@
+import type React from 'react';
+import Linkify from 'react-linkify';
+import { A } from './preflighted';
+import { useTheme } from './ThemeProvider';
+
+// Similar to twitter
+const MAX_LINK_TEXT_LENGTH = 32;
+
+export default function LinkifiedText({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { textStyles } = useTheme();
+  return (
+    <Linkify
+      componentDecorator={(
+        decoratedHref: string,
+        decoratedText: string,
+        key: number
+      ) => (
+        <A
+          target="blank"
+          className={textStyles.link}
+          href={decoratedHref}
+          key={key}
+        >
+          {decoratedText.length > MAX_LINK_TEXT_LENGTH
+            ? decoratedText.slice(0, MAX_LINK_TEXT_LENGTH) + '...'
+            : decoratedText}
+        </A>
+      )}
+    >
+      {children}
+    </Linkify>
+  );
+}

--- a/packages/dialect-react-ui/components/common/ThemeProvider.tsx
+++ b/packages/dialect-react-ui/components/common/ThemeProvider.tsx
@@ -97,6 +97,7 @@ export type IncomingThemeValues = {
   bigButtonLoading?: string;
   divider?: string;
   highlighted?: string;
+  scrollbar?: string;
 };
 
 export type IncomingThemeVariables = Partial<
@@ -180,7 +181,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
     notificationsDivider: 'dt-hidden',
     modalWrapper:
       'dt-fixed dt-z-50 dt-top-0 dt-w-full dt-h-full dt-right-0 sm:dt-absolute sm:dt-top-16 sm:dt-w-[30rem] sm:dt-h-[40rem]',
-    modal: 'dt-rounded-none sm:dt-rounded-3xl',
+    modal: 'dt-rounded-none dt-shadow-md sm:dt-rounded-3xl',
     button:
       'dt-bg-black dt-text-white dt-border dt-border-black hover:dt-opacity-60',
     secondaryButton:
@@ -196,6 +197,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
       'dt-min-h-[42px] dt-border dt-border-black dt-opacity-20 dt-bg-transparent',
     divider: 'dt-h-px dt-opacity-10 dt-bg-current',
     highlighted: 'dt-px-4 dt-py-3 dt-rounded-lg',
+    scrollbar: 'dt-light-scrollbar',
   },
   dark: {
     colors: {
@@ -279,6 +281,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
       'dt-min-h-[42px] dt-border dt-border-white dt-opacity-20 dt-bg-transparent',
     divider: 'dt-h-px dt-opacity-30 dt-bg-current',
     highlighted: 'dt-px-4 dt-py-3 dt-rounded-lg',
+    scrollbar: 'dt-dark-scrollbar',
   },
 };
 

--- a/packages/dialect-react-ui/components/common/ThemeProvider.tsx
+++ b/packages/dialect-react-ui/components/common/ThemeProvider.tsx
@@ -90,14 +90,17 @@ export type IncomingThemeValues = {
   modalWrapper?: string;
   modal?: string;
   button?: string;
-  secondaryButton?: string;
-  secondaryDangerButton?: string;
   buttonLoading?: string;
-  bigButton?: string;
-  bigButtonLoading?: string;
+  secondaryButton?: string;
+  secondaryButtonLoading?: string;
+  secondaryDangerButton?: string;
+  secondaryDangerButtonLoading?: string;
   divider?: string;
   highlighted?: string;
   scrollbar?: string;
+  // TODO: Deprecate BigButton
+  bigButton?: string;
+  bigButtonLoading?: string;
 };
 
 export type IncomingThemeVariables = Partial<
@@ -114,6 +117,7 @@ export type ThemeValues = Required<
 
 export const defaultVariables: Record<ThemeType, ThemeValues> = {
   light: {
+    // TODO: either put all colors in the theme or define as css-custom-properties to simplify overriding
     colors: {
       bg: 'dt-bg-white',
       secondary: '',
@@ -122,7 +126,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
       primary: 'dt-text-black',
       accent: 'dt-text-black',
       accentSolid: 'dt-text-[#5895B9]',
-      highlight: 'dt-bg-[#ABABAB]/10',
+      highlight: 'dt-bg-subtle-day',
       highlightSolid: 'dt-bg-[#F2F3F2]',
       toggleBackground: 'dt-bg-[#D6D6D6]',
       toggleBackgroundActive: 'dt-bg-[#25BC3B]',
@@ -170,7 +174,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
     input:
       'dt-text-xs dt-text-neutral-700 dt-px-2 dt-py-2 dt-border-b dt-border-neutral-600 focus:dt-rounded-md dt-outline-none focus:dt-ring focus:dt-ring-black focus:dt-border-0',
     outlinedInput:
-      'dt-text-sm dt-text-black dt-bg-[#ABABAB]/10 dt-px-3 dt-py-2.5 dt-border-2 dt-border-[#ABABAB]/10 dt-rounded-lg dt-focus:border-black dt-focus:outline-none',
+      'dt-text-sm dt-text-black dt-bg-subtle-day dt-px-3 dt-py-2.5 dt-border-2 dt-border-subtle-day dt-rounded-lg dt-focus:border-black dt-focus:outline-none',
     textArea:
       'dt-text-sm dt-text-neutral-800 dt-bg-white dt-border dt-rounded-2xl dt-px-2 dt-py-1 dt-border-neutral-300 dt-placeholder-neutral-400 dt-pr-10 dt-outline-none',
     messageBubble:
@@ -184,20 +188,21 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
     modal: 'dt-rounded-none dt-shadow-md sm:dt-rounded-3xl',
     button:
       'dt-bg-black dt-text-white dt-border dt-border-black hover:dt-opacity-60',
+    buttonLoading:
+      'dt-min-h-[42px] dt-border dt-border-black dt-opacity-20 !dt-text-black !dt-bg-transparent',
     secondaryButton:
       'dt-bg-transparent dt-text-black dt-border dt-border-black hover:dt-bg-black/10',
-    // TODO: colors in the theme
+    secondaryButtonLoading: '',
     secondaryDangerButton:
-      'dt-bg-transparent dt-text-[#DE5454] dt-border dt-border-[#DE5454] hover:dt-bg-[#DE5454]/10',
-    // TODO: buttonLoading for secondary
-    buttonLoading:
-      'dt-min-h-[42px] dt-border dt-border-black dt-opacity-20 dt-bg-transparent',
-    bigButton: 'dt-text-black dt-border dt-border-black hover:dt-opacity-60',
-    bigButtonLoading:
-      'dt-min-h-[42px] dt-border dt-border-black dt-opacity-20 dt-bg-transparent',
+      'dt-bg-transparent dt-text-error-day dt-border dt-border-error-day hover:dt-bg-error-day/10',
+    secondaryDangerButtonLoading: 'dt-min-h-[42px] dt-text-error-day/40',
     divider: 'dt-h-px dt-opacity-10 dt-bg-current',
     highlighted: 'dt-px-4 dt-py-3 dt-rounded-lg',
     scrollbar: 'dt-light-scrollbar',
+    // TODO: Deprecate BigButton
+    bigButton: 'dt-text-black dt-border dt-border-black hover:dt-opacity-60',
+    bigButtonLoading:
+      'dt-min-h-[42px] dt-border dt-border-black dt-opacity-20 dt-bg-transparent',
   },
   dark: {
     colors: {
@@ -208,7 +213,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
       primary: 'dt-text-white',
       accent: 'dt-text-white',
       accentSolid: 'dt-text-white',
-      highlight: 'dt-bg-[#ABABAB]/20',
+      highlight: 'dt-bg-subtle-night',
       highlightSolid: 'dt-bg-[#262626]',
       toggleBackground: 'dt-bg-[#5B5B5B]',
       toggleBackgroundActive: 'dt-bg-[#25BC3B]',
@@ -255,7 +260,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
     input:
       'dt-text-xs dt-text-white dt-bg-black dt-px-2 dt-py-2 dt-border-b dt-border-neutral-600 focus:dt-rounded-md dt-outline-none focus:dt-ring focus:dt-ring-white',
     outlinedInput:
-      'dt-text-sm dt-text-white dt-bg-[#ABABAB]/10 dt-px-3 dt-py-2.5 dt-border-2 dt-border-neutral-600 dt-rounded-lg focus:dt-border-white focus:dt-outline-none',
+      'dt-text-sm dt-text-white dt-bg-subtle-night dt-px-3 dt-py-2.5 dt-border-2 dt-border-neutral-600 dt-rounded-lg focus:dt-border-white focus:dt-outline-none',
     textArea:
       'dt-text-sm dt-text-neutral-200 dt-bg-black dt-border dt-rounded-2xl dt-px-2 dt-py-1 dt-border-neutral-600 dt-placeholder-neutral-600 dt-pr-10 dt-outline-none',
     messageBubble:
@@ -270,18 +275,22 @@ export const defaultVariables: Record<ThemeType, ThemeValues> = {
     modal: 'dt-rounded-none dt-shadow-md sm:dt-rounded-3xl',
     button:
       'dt-bg-white dt-text-black dt-border dt-border-white hover:dt-opacity-60',
-    secondaryButton:
-      'dt-bg-transparent dt-text-white dt-border dt-border-white hover:dt-bg-white/10',
-    secondaryDangerButton:
-      'dt-bg-transparent dt-text-[#DE5454] dt-border dt-border-[#DE5454] hover:dt-bg-[#DE5454]/10',
     buttonLoading:
       'dt-min-h-[42px] dt-border dt-border-white dt-opacity-20 dt-bg-transparent',
-    bigButton: 'dt-text-white dt-border dt-border-white hover:dt-opacity-60',
-    bigButtonLoading:
-      'dt-min-h-[42px] dt-border dt-border-white dt-opacity-20 dt-bg-transparent',
+    secondaryButton:
+      'dt-bg-transparent dt-text-white dt-border dt-border-white hover:dt-bg-white/10',
+    secondaryButtonLoading: '',
+    secondaryDangerButton:
+      'dt-bg-transparent dt-text-error-night dt-border dt-border-error-night hover:dt-bg-error-night/10',
+    secondaryDangerButtonLoading:
+      'dt-min-h-[42px] dt-text-error-night/10 dt-opacity-20',
     divider: 'dt-h-px dt-opacity-30 dt-bg-current',
     highlighted: 'dt-px-4 dt-py-3 dt-rounded-lg',
     scrollbar: 'dt-dark-scrollbar',
+    // TODO: Deprecate BigButton
+    bigButton: 'dt-text-white dt-border dt-border-white hover:dt-opacity-60',
+    bigButtonLoading:
+      'dt-min-h-[42px] dt-border dt-border-white dt-opacity-20 dt-bg-transparent',
   },
 };
 

--- a/packages/dialect-react-ui/components/common/index.ts
+++ b/packages/dialect-react-ui/components/common/index.ts
@@ -1,3 +1,4 @@
 export * from './primitives';
 
 export { default as NetworkBadge } from './NetworkBadge';
+export { default as LinkifiedText } from './LinkifiedText';

--- a/packages/dialect-react-ui/components/common/primitives.tsx
+++ b/packages/dialect-react-ui/components/common/primitives.tsx
@@ -88,6 +88,7 @@ export function Loader() {
 
 export function Button(props: {
   defaultStyle?: string;
+  loadingStyle?: string;
   className?: string;
   onClick?: () => void;
   disabled?: boolean;
@@ -95,14 +96,16 @@ export function Button(props: {
   children: React.ReactNode;
 }): JSX.Element {
   const { button, buttonLoading, textStyles } = useTheme();
-  const defaultStyle = props.defaultStyle || button;
+  const defaultClassName = props.defaultStyle || button;
+  const loadingClassName = props.loadingStyle || buttonLoading;
 
   return (
     <ButtonBase
       className={cs(
         'dt-min-w-120 dt-px-4 dt-py-2 dt-rounded-lg dt-transition-all dt-flex dt-flex-row dt-items-center dt-justify-center',
         textStyles.buttonText,
-        !props.loading ? defaultStyle : buttonLoading,
+        defaultClassName,
+        props.loading && loadingClassName,
         props.className
       )}
       onClick={props.onClick}
@@ -113,6 +116,7 @@ export function Button(props: {
   );
 }
 
+// TODO: Deprecate BigButton
 export function BigButton(props: {
   className?: string;
   onClick?: () => void;

--- a/packages/dialect-react-ui/index.css
+++ b/packages/dialect-react-ui/index.css
@@ -140,7 +140,6 @@
   }
 }
 
-
 .dialect ::before,
 .dialect ::after {
   --tw-content: '';
@@ -470,6 +469,39 @@
   height: auto;
 }
 
+.dialect *::-webkit-scrollbar {
+  width: 12px; /* Mostly for vertical scrollbars */
+  height: 12px; /* Mostly for horizontal scrollbars */
+}
+.dialect *::-webkit-scrollbar-track {
+  /* Background */
+  background: transparent;
+}
+.dt-light-scrollbar {
+  /* Firefox: Foreground, Background */
+  scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+}
+.dt-light-scrollbar::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  /* Foreground */
+  background: transparent;
+  /* hack to add visual margin to thumb https://stackoverflow.com/questions/29866759/how-do-i-add-a-margin-to-a-css-webkit-scrollbar */
+  box-shadow: inset 0 0 10px 10px rgba(0, 0, 0, 0.3);
+  border: solid 3px transparent;
+}
+.dt-dark-scrollbar {
+  /* Firefox: Foreground, Background */
+  scrollbar-color: rgba(255, 255, 255, 0.3) transparent;
+}
+.dt-dark-scrollbar::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  /* Foreground */
+  background: transparent;
+  /* hack to add visual margin to thumb https://stackoverflow.com/questions/29866759/how-do-i-add-a-margin-to-a-css-webkit-scrollbar */
+  box-shadow: inset 0 0 10px 10px rgba(255, 255, 255, 0.3);
+  border: solid 3px transparent;
+}
+
 /* Hide scrollbar for Chrome, Safari and Opera */
 .dt-no-scrollbar::-webkit-scrollbar {
   display: none;
@@ -477,8 +509,8 @@
 
 /* Hide scrollbar for IE, Edge and Firefox */
 .dt-no-scrollbar {
-  -ms-overflow-style: none;  /* IE and Edge */
-  scrollbar-width: none;  /* Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
 }
 
 @tailwind components;

--- a/packages/dialect-react-ui/tailwind.config.js
+++ b/packages/dialect-react-ui/tailwind.config.js
@@ -3,6 +3,14 @@ module.exports = {
   theme: {
     extend: {
       inter: ['Inter, sans-serif'],
+      colors: {
+        'subtle-day': '#C5C5C530',
+        'secondary-back-day': '#17171710',
+        'error-day': '#D62929',
+        'subtle-night': '#ABABAB10',
+        'secondary-back-night': '#171717',
+        'error-night': '#DE5454',
+      },
     },
   },
   variants: {

--- a/packages/dialect-react/components/DialectContext/index.tsx
+++ b/packages/dialect-react/components/DialectContext/index.tsx
@@ -24,6 +24,7 @@ import {
   ParsedErrorType,
 } from '../../utils/errors';
 import { connected, isAnchorWallet } from '../../utils/helpers';
+import type { Message } from '@dialectlabs/web3';
 import type SolWalletAdapter from '@project-serum/sol-wallet-adapter';
 import type { BaseSolletWalletAdapter } from '@solana/wallet-adapter-sollet';
 import type { EncryptionProps } from '@dialectlabs/web3/lib/es/api/text-serde';
@@ -46,11 +47,6 @@ const swrFetchMetadata = (
   _: string,
   ...args: Parameters<typeof fetchMetadata>
 ) => fetchMetadata(...args);
-
-interface Message {
-  text: string;
-  timestamp: number;
-}
 
 type PropsType = {
   children: JSX.Element;


### PR DESCRIPTION
## Context
It's actually a OS-specific setting how to show scrollbars when not scrolling. Defaults to "only while scrolling" on macOS, and to "always" on windows, linux.
<img width="780" alt="Screenshot 2022-04-14 at 13 57 53" src="https://user-images.githubusercontent.com/2504771/163378664-2e2ffc68-1127-442e-8df8-8c604d1472ce.png">


These PR style scrollbars to make them more elegant if shown (`scrollbar` key introduced in theme variables). It also hides scrollbars from textarea completly, since textarrea resizes with new text added.

### before:
<img width="1104" alt="Screenshot 2022-04-14 at 13 32 49" src="https://user-images.githubusercontent.com/2504771/163363369-5652b9cb-0005-4c17-96a1-48401ff1b860.png">

### after:
<img width="1063" alt="Screenshot 2022-04-14 at 13 37 43" src="https://user-images.githubusercontent.com/2504771/163363356-07f601f3-6820-41ea-a7fd-d7ce458558bd.png">

