### PR TITLE
when new wallet data recieved reset dialect address

### DIFF
--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [UNRELEASED]
+- Reset dialect address when wallet changed
 
 ## [0.1.0] - 2022-02-12
 

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
@@ -41,6 +41,10 @@ const ThreadPage = ({
     [dialect]
   );
 
+  useEffect(() => {
+    setDialectAddress('');
+  }, [wallet])
+
   if (!dialectAddress) {
     if (!inbox) {
       return null;


### PR DESCRIPTION
Initial bug: route away from encrypted message if switching to phantom

When wallet was changed, have to reset address dialect to rest not valid thread anymore.

Some videos with current behaviour are attached.. 

https://user-images.githubusercontent.com/78972087/163554494-87fc920d-97da-4789-95fb-2fd1fe49b92e.mov


https://user-images.githubusercontent.com/78972087/163554506-d3607325-77c5-484f-ab2a-5382f2ce2098.mov

 