### PR TITLE
fix: prevent long message from expanding entire chat

### DIFF
--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- fix: prevent long message from expanding entire chat
+
 ## [0.1.0] - 2022-02-12
 
 - First version for open source. Includes pre-built notification center components in react-ui package, and first

--- a/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/pages/ThreadPage/index.tsx
@@ -65,7 +65,8 @@ const ThreadPage = ({
   }
 
   return (
-    <div className="dt-flex dt-flex-col dt-flex-1">
+    <div className="dt-flex dt-flex-col dt-flex-1 dt-min-w-[0px]">
+      {/* ↑ The min-width: 0 is used to prevent the column from overflow the container. Explanation: https://makandracards.com/makandra/66994-css-flex-and-min-width */}
       <div className="dt-px-4 dt-py-1 dt-flex dt-justify-between dt-border-b dt-border-neutral-900 dt-items-center">
         {/* TODO: replace with IconButton to be sematic */}
         <div


### PR DESCRIPTION
### Before:
<img width="1103" alt="Screenshot 2022-04-21 at 21 06 59" src="https://user-images.githubusercontent.com/2504771/164513904-19d2654f-3739-4b82-aee6-dfa165fddb72.png">

### After:
<img width="1041" alt="Screenshot 2022-04-21 at 21 09 11" src="https://user-images.githubusercontent.com/2504771/164514192-0987d175-e2f9-4360-9a27-f3903ee37eaa.png">

Explanation: default min-width for flex elements is auto, overcompeting width and max-width, which results in overflowing 
