### PR TITLE
Avoid fetching images urls multiple times

### DIFF
--- a/packages/dialect-react-ui/package.json
+++ b/packages/dialect-react-ui/package.json
@@ -28,6 +28,7 @@
     "lint:fix": "yarn lint --fix"
   },
   "dependencies": {
+    "@cardinal/namespaces": "^1.1.0",
     "@cardinal/namespaces-components": "2.5.0",
     "@dialectlabs/web3": "^0.2.0",
     "@headlessui/react": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,7 +1233,7 @@
     eip1193-provider "^1.0.1"
     js-sha3 "^0.8.0"
 
-"@cardinal/certificates@^1.2.3", "@cardinal/certificates@^1.3.0":
+"@cardinal/certificates@^1.2.3", "@cardinal/certificates@^1.3.0", "@cardinal/certificates@^1.3.4":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@cardinal/certificates/-/certificates-1.3.4.tgz#151e9d80624cb7f90185c15cbca5bbafcdb8fd00"
   integrity sha512-IVr8CGS3OP3fe7L/W1Y4FIaCGf6223vPx5wVeQ/ug9NO6uOI9aRgayFP4j2ZOGrPKMz8SdRj12xgPX6LGc+JFg==
@@ -1244,6 +1244,23 @@
     mocha "^9.2.0"
     ts-mocha "^9.0.2"
     typescript "^4.5.5"
+
+"@cardinal/common@^1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@cardinal/common/-/common-1.0.10.tgz#e40a84c7f253db9154f3022f2e1ef6b8a2ff40c7"
+  integrity sha512-FCgatr08oyimIDkOk6Fi8gQLtWACnS3MTaMSjZfkXgQa1Wd+58s0k1DBG6IxWthmlSpl6w1/+kN0JfeWoVKO0w==
+  dependencies:
+    "@cardinal/stake-pool" "^1.1.1"
+    "@metaplex-foundation/mpl-token-metadata" "^1.2.5"
+    "@project-serum/anchor" "^0.22.1"
+    "@saberhq/anchor-contrib" "^1.12.48"
+    "@saberhq/solana-contrib" "^1.12.48"
+    "@saberhq/token-utils" "^1.12.48"
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/spl-token" "^0.1.8"
+    "@ubeswap/token-math" "^4.4.4"
+    tiny-invariant "^1.2.0"
+    tslib "^2.3.1"
 
 "@cardinal/namespaces-components@2.5.0":
   version "2.5.0"
@@ -1299,6 +1316,18 @@
     twin.macro "^2.8.2"
     typescript "^4.1.2"
 
+"@cardinal/namespaces@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@cardinal/namespaces/-/namespaces-1.1.0.tgz#903a30875e75bf877a30de1c30434a073f4cabe7"
+  integrity sha512-IPrw+W4SyJ9twrkEOm87+Ak7uzM24QF88JLQLYGdpXIgKNbFjpWLuMYGzOFmx17htXqSOUSlGKpGVvB3PlBQsg==
+  dependencies:
+    "@cardinal/certificates" "^1.2.3"
+    "@cardinal/common" "^1.0.10"
+    "@cardinal/namespaces" "^2.0.42"
+    "@cardinal/token-manager" "^1.1.0"
+    "@metaplex-foundation/mpl-token-metadata" "^1.2.5"
+    "@project-serum/anchor" "^0.20.1"
+
 "@cardinal/namespaces@^2.0.42":
   version "2.0.59"
   resolved "https://registry.yarnpkg.com/@cardinal/namespaces/-/namespaces-2.0.59.tgz#9e251c3a38f78faca58e208d1c5f2e10fa8c829b"
@@ -1324,6 +1353,37 @@
     "@saberhq/solana-contrib" "^1.12.23"
     "@solana/spl-token" "^0.1.8"
     typescript "^4.5.4"
+
+"@cardinal/stake-pool@^1.1.1":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@cardinal/stake-pool/-/stake-pool-1.1.9.tgz#aa148066779dfec17bef58d5f612b5225ae85739"
+  integrity sha512-1b6jyiMt4N1xjA1bC3dbETpIq3GoHYyGc5RPSXjAKyWWWBU001Ti+/wipI5bKx7yl6Q5UDP68Rbu93CGLagqiA==
+  dependencies:
+    "@cardinal/certificates" "^1.3.4"
+    "@cardinal/common" "^1.0.10"
+    "@metaplex-foundation/mpl-token-metadata" "^1.2.4"
+    "@project-serum/anchor" "0.21.0"
+    "@saberhq/anchor-contrib" "^1.12.47"
+    "@saberhq/solana-contrib" "^1.12.47"
+    "@solana/spl-token" "^0.1.8"
+    "@types/mocha" "^9.1.0"
+    mocha "^9.1.4"
+    ts-mocha "^8.0.0"
+    typescript "^4.5.5"
+
+"@cardinal/token-manager@^1.1.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@cardinal/token-manager/-/token-manager-1.2.1.tgz#b6a912d13e6e5a8bd1349aeec9a7df5e80873b42"
+  integrity sha512-HaG2u9dOP/mGO4RAo4wPhXUu60rsDJrwLOJvf18qrCrjGLCp5ssiguMm8j19oktkMou1ri3Zs6WRQ3h67/AY9Q==
+  dependencies:
+    "@metaplex-foundation/mpl-token-metadata" "^1.2.3"
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/spl-token" "^0.1.8"
+    borsh "^0.7.0"
+    bs58 "^4.0.1"
+    superstruct "^0.15.4"
+    tiny-invariant "^1.2.0"
+    tslib "^2.3.1"
 
 "@csstools/normalize.css@*":
   version "12.0.0"
@@ -1922,7 +1982,7 @@
     "@solana/spl-token" "^0.1.8"
     "@solana/web3.js" "^1.31.0"
 
-"@metaplex-foundation/mpl-token-metadata@^1.1.0":
+"@metaplex-foundation/mpl-token-metadata@^1.1.0", "@metaplex-foundation/mpl-token-metadata@^1.2.3", "@metaplex-foundation/mpl-token-metadata@^1.2.4", "@metaplex-foundation/mpl-token-metadata@^1.2.5":
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@metaplex-foundation/mpl-token-metadata/-/mpl-token-metadata-1.2.5.tgz#1a927b1c7d30cd634a1e4782022712a02f6865c2"
   integrity sha512-pxRG53JsTSwXpiJJMHNulJhH8kO3hHztQ3QxslUoKw2hBYKXsg9TGsiHgNIhN2MPZGBJ2pDeK6kNGv0sd54HhA==
@@ -2087,6 +2147,27 @@
     snake-case "^3.0.4"
     toml "^3.0.0"
 
+"@project-serum/anchor@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.21.0.tgz#ad5fb33744991ec1900cdb2fd22707c908b12b5f"
+  integrity sha512-flRuW/F+iC8mitNokx82LOXyND7Dyk6n5UUPJpQv/+NfySFrNFlzuQZaBZJ4CG5g9s8HS/uaaIz1nVkDR8V/QA==
+  dependencies:
+    "@project-serum/borsh" "^0.2.4"
+    "@solana/web3.js" "^1.17.0"
+    base64-js "^1.5.1"
+    bn.js "^5.1.2"
+    bs58 "^4.0.1"
+    buffer-layout "^1.2.2"
+    camelcase "^5.3.1"
+    cross-fetch "^3.1.5"
+    crypto-hash "^1.3.0"
+    eventemitter3 "^4.0.7"
+    find "^0.3.0"
+    js-sha256 "^0.9.0"
+    pako "^2.0.3"
+    snake-case "^3.0.4"
+    toml "^3.0.0"
+
 "@project-serum/anchor@0.23.0", "@project-serum/anchor@^0.23.0":
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.23.0.tgz#2b2eb6b51601b073e8db26663aa2d6c2f2841771"
@@ -2108,7 +2189,28 @@
     snake-case "^3.0.4"
     toml "^3.0.0"
 
-"@project-serum/borsh@^0.2.2", "@project-serum/borsh@^0.2.5":
+"@project-serum/anchor@^0.22.1":
+  version "0.22.1"
+  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.22.1.tgz#698a9620f94691de0a12bbc650a5c8380e2f0e8a"
+  integrity sha512-5pHeyvQhzLahIQ8aZymmDMZJAJFklN0joZdI+YIqFkK2uU/mlKr6rBLQjxysf/j1mLLiNG00tdyLfUtTAdQz7w==
+  dependencies:
+    "@project-serum/borsh" "^0.2.5"
+    "@solana/web3.js" "^1.17.0"
+    base64-js "^1.5.1"
+    bn.js "^5.1.2"
+    bs58 "^4.0.1"
+    buffer-layout "^1.2.2"
+    camelcase "^5.3.1"
+    cross-fetch "^3.1.5"
+    crypto-hash "^1.3.0"
+    eventemitter3 "^4.0.7"
+    find "^0.3.0"
+    js-sha256 "^0.9.0"
+    pako "^2.0.3"
+    snake-case "^3.0.4"
+    toml "^3.0.0"
+
+"@project-serum/borsh@^0.2.2", "@project-serum/borsh@^0.2.4", "@project-serum/borsh@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@project-serum/borsh/-/borsh-0.2.5.tgz#6059287aa624ecebbfc0edd35e4c28ff987d8663"
   integrity sha512-UmeUkUoKdQ7rhx6Leve1SssMR/Ghv8qrEiyywyxSWg7ooV7StdpPBhciiy5eB3T0qU1BXvdRNC8TdrkxK7WC5Q==
@@ -2249,6 +2351,17 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.2.tgz#7a26e63b1bdaf654bcce2176a38b83f7f576327e"
   integrity sha512-oe5WJEDaVsW8fBlGT7udrSCgOwWfoYHQOmSpnh8X+0GXpqqcRCP8k4y+Dxb0taWJDPpB+rdDUtumIiBwkY9qGA==
 
+"@saberhq/anchor-contrib@^1.12.47", "@saberhq/anchor-contrib@^1.12.48":
+  version "1.12.65"
+  resolved "https://registry.yarnpkg.com/@saberhq/anchor-contrib/-/anchor-contrib-1.12.65.tgz#eb3dc4edf6e8f3e036bda5efdd6e1dfdd87c3cfa"
+  integrity sha512-AFmTmVKJ6IFQ04DH8+iV/z71XoxKG6szf+Z4F0CRHWqB7NVQ14Jgq+MO3MvM48JhLTYVpFGXD0YQ8NCORf8Ayw==
+  dependencies:
+    "@saberhq/solana-contrib" "^1.12.65"
+    eventemitter3 "^4.0.7"
+    lodash.camelcase "^4.3.0"
+    lodash.mapvalues "^4.6.0"
+    tslib "^2.4.0"
+
 "@saberhq/solana-contrib@^1.12.23", "@saberhq/solana-contrib@^1.12.26", "@saberhq/solana-contrib@^1.12.59":
   version "1.12.59"
   resolved "https://registry.yarnpkg.com/@saberhq/solana-contrib/-/solana-contrib-1.12.59.tgz#7be4d4c9e56a4ecd76e89aad29809e6748fe041b"
@@ -2262,6 +2375,19 @@
     tiny-invariant "^1.2.0"
     tslib "^2.3.1"
 
+"@saberhq/solana-contrib@^1.12.47", "@saberhq/solana-contrib@^1.12.48", "@saberhq/solana-contrib@^1.12.65":
+  version "1.12.65"
+  resolved "https://registry.yarnpkg.com/@saberhq/solana-contrib/-/solana-contrib-1.12.65.tgz#19baa57d6252190d62bcf5c75bfe195d70bc9289"
+  integrity sha512-wzO98nf+fYwsCaEpZ/uiXVskQAwlgdGGQEnJnNMBZVA4rW91hSa8zpIUZWx3RdbtBfQUUY5hYUd/uopgjqDcug==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@types/promise-retry" "^1.1.3"
+    "@types/retry" "^0.12.1"
+    promise-retry "^2.0.1"
+    retry "^0.13.1"
+    tiny-invariant "^1.2.0"
+    tslib "^2.4.0"
+
 "@saberhq/solana-contrib@^1.12.62":
   version "1.12.62"
   resolved "https://registry.yarnpkg.com/@saberhq/solana-contrib/-/solana-contrib-1.12.62.tgz#9c8bd9965f1b63cebd544b53a1082aca35a18cd0"
@@ -2274,6 +2400,18 @@
     retry "^0.13.1"
     tiny-invariant "^1.2.0"
     tslib "^2.3.1"
+
+"@saberhq/token-utils@^1.12.48":
+  version "1.12.65"
+  resolved "https://registry.yarnpkg.com/@saberhq/token-utils/-/token-utils-1.12.65.tgz#f2c01aabbb41764eea61527b3ebb546473fc6921"
+  integrity sha512-gQHbe87ytoS9hpHERN+X6DqaFWoDX/enbKgkx2iNHBceMFAFUzk44oqILi8rmsP7+p6PgtAJmVkSYghZR9kUew==
+  dependencies:
+    "@saberhq/solana-contrib" "^1.12.65"
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/spl-token" "^0.1.8"
+    "@ubeswap/token-math" "^4.4.6"
+    tiny-invariant "^1.2.0"
+    tslib "^2.4.0"
 
 "@saberhq/use-solana@^1.12.26":
   version "1.12.59"
@@ -3240,6 +3378,11 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
+"@types/mocha@^9.1.0":
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.1.tgz#e7c4f1001eefa4b8afbd1eee27a237fee3bf29c4"
+  integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
+
 "@types/node@*":
   version "17.0.10"
   resolved "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz"
@@ -3591,6 +3734,17 @@
   dependencies:
     "@typescript-eslint/types" "5.19.0"
     eslint-visitor-keys "^3.0.0"
+
+"@ubeswap/token-math@^4.4.4", "@ubeswap/token-math@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@ubeswap/token-math/-/token-math-4.4.6.tgz#8f3c3eafd73f0c30f2e3eaf68595f888f6955635"
+  integrity sha512-wEdexdyhymaSnyvJ2dx512Fxzxo/dkMqIRZQ9cePTqhJwyUg9jOpi2XAq0FAOf7KQEdYgfDSIMrkWeBNvfoYVQ==
+  dependencies:
+    big.js "^6.1.1"
+    decimal.js-light "^2.5.1"
+    tiny-invariant "^1.2.0"
+    toformat "^2.0.0"
+    tslib "^2.3.1"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -4303,6 +4457,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+big.js@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.1.1.tgz#63b35b19dc9775c94991ee5db7694880655d5537"
+  integrity sha512-1vObw81a8ylZO5ePrtMay0n018TcftpTA5HFKDaSuiUDBo8biRBtjIobw60OpwuvrGk+FsxKamqN4cnmj/eXdg==
 
 bignumber.js@^9.0.2:
   version "9.0.2"
@@ -5315,6 +5474,11 @@ decamelize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
+
+decimal.js-light@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/decimal.js-light/-/decimal.js-light-2.5.1.tgz#134fd32508f19e208f4fb2f8dac0d2626a867934"
+  integrity sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==
 
 decimal.js@^10.2.1:
   version "10.3.1"
@@ -8195,6 +8359,11 @@ lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz"
@@ -8209,6 +8378,11 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
+lodash.mapvalues@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
+  integrity sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=
 
 lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -8474,7 +8648,7 @@ mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-mocha@^9.2.0:
+mocha@^9.1.4, mocha@^9.2.0:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.2.2.tgz#d70db46bdb93ca57402c809333e5a84977a88fb9"
   integrity sha512-L6XC3EdwT6YrIk0yXpavvLkn8h+EU+Y5UcCHKECyMbdUIxyMuZj4bX4U9e1nvnvUUvQVsV2VHQr5zLdcUkhW/g==
@@ -10973,6 +11147,11 @@ superstruct@^0.14.2:
   resolved "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz"
   integrity sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ==
 
+superstruct@^0.15.4:
+  version "0.15.4"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.15.4.tgz#e3381dd84ca07e704e19f69eda74eee1a5efb1f9"
+  integrity sha512-eOoMeSbP9ZJChNOm/9RYjE+F36rYR966AAqeG3xhQB02j2sfAUXDp4EQ/7bAOqnlJnuFDB8yvOu50SocvKpUEw==
+
 supports-color@8.1.1, supports-color@^8.0.0, supports-color@^8.1.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
@@ -11295,6 +11474,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+toformat@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/toformat/-/toformat-2.0.0.tgz#7a043fd2dfbe9021a4e36e508835ba32056739d8"
+  integrity sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==
+
 toggle-selection@^1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz"
@@ -11353,6 +11537,15 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
+ts-mocha@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/ts-mocha/-/ts-mocha-8.0.0.tgz#962d0fa12eeb6468aa1a6b594bb3bbc818da3ef0"
+  integrity sha512-Kou1yxTlubLnD5C3unlCVO7nh0HERTezjoVhVw/M5S1SqoUec0WgllQvPk3vzPMc6by8m6xD1uR1yRf8lnVUbA==
+  dependencies:
+    ts-node "7.0.1"
+  optionalDependencies:
+    tsconfig-paths "^3.5.0"
+
 ts-mocha@^9.0.2:
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/ts-mocha/-/ts-mocha-9.0.2.tgz#c1ef0248874d04a0f26dd9bd8d88e617a8d82ab1"
@@ -11395,6 +11588,11 @@ tslib@^2.0.3, tslib@^2.3.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Before we would fetch the image url every time the avatar is displayed. So if a user sends 100 messages in the threads then we would have to fetch the same image url 100 times. This is clearly not scalable as the number users and messages grow on our platform.

**Before**
<img width="1800" alt="Screen Shot 2022-04-23 at 12 35 09 PM" src="https://user-images.githubusercontent.com/93460079/164915176-0bf680fc-78c5-47af-9300-d58ce150b08d.png">

**After**
<img width="1800" alt="Screen Shot 2022-04-23 at 12 37 07 PM" src="https://user-images.githubusercontent.com/93460079/164915193-155df8f3-870d-492a-9f0e-28e84793895f.png">


