### PR TITLE
bundle size reducing(first iteration)

### DIFF
--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- mark library as side effect free
+
 ## [0.8.3] - 2022-05-08
 
 - Fix render loop caused by default theme variable

--- a/packages/dialect-react-ui/package.json
+++ b/packages/dialect-react-ui/package.json
@@ -4,6 +4,7 @@
   "description": "Dialect's react UI components",
   "license": "MIT",
   "private": false,
+  "sideEffects": false,
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/types/index.d.ts",

--- a/packages/dialect-react/CHANGELOG.md
+++ b/packages/dialect-react/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- mark library as side effect free
+
 ## [0.5.1] - 2022-05-04
 
 - fix: wallet-refistry url

--- a/packages/dialect-react/package.json
+++ b/packages/dialect-react/package.json
@@ -4,6 +4,7 @@
   "description": "React wrappers for Dialect's web3 notifications",
   "license": "MIT",
   "private": false,
+  "sideEffects": false,
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/types/index.d.ts",
@@ -30,7 +31,6 @@
     "@dialectlabs/web3": "^0.3.1",
     "@project-serum/anchor": "^0.23.0",
     "object-hash": "^3.0.0",
-    "@solana/web3.js": "1.38.0",
     "swr": "^0.5.6",
     "unfetch": "^4.2.0"
   },
@@ -43,6 +43,7 @@
     "react": ">=17",
     "@saberhq/use-solana": "^1.12.62",
     "@solana/wallet-adapter-react": "^0.15.4",
-    "@solana/wallet-adapter-base": "^0.9.5"
+    "@solana/wallet-adapter-base": "^0.9.5",
+    "@solana/web3.js": "1.x"
   }
 }


### PR DESCRIPTION
with this flag webpack will do more agressive tree shaking, so it'll help to avoid unnecessary dependencies at runtime(e.g. cardinal library which as unusued if we use notification mode)

screenshots attached, please do not look at absolute values, it's not real numbers(cause multiple libraries could be deduplicated) and further reducing can be done.

as per discussion with @cbosborn this is a first iteration with a quick(hacky?) fix to reduce bundle size. Further improvements will come soon..

As we can see current reduction is around **20%** due to cardinal exclusion

before(700kb):
<img width="389" alt="Screenshot 2022-05-06 at 22 42 46" src="https://user-images.githubusercontent.com/5163918/167206621-4ea3f990-0017-4852-b160-28140c4716fa.png">

after(500kb):
<img width="354" alt="Screenshot 2022-05-06 at 22 42 01" src="https://user-images.githubusercontent.com/5163918/167206499-37d775ec-edf8-44ad-8378-412264113e31.png">

