### PR TITLE
extract wallet adapter for use-solana compatability 

### DIFF
--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- better use-solana compatability
 - mark library as side effect free
 
 ## [0.8.3] - 2022-05-08

--- a/packages/dialect-react/components/ApiContext/index.tsx
+++ b/packages/dialect-react/components/ApiContext/index.tsx
@@ -30,7 +30,7 @@ import {
   extractWalletAdapter,
   isAnchorWallet,
 } from '../../utils/helpers';
-import type { WalletName } from '@solana/wallet-adapter-base';
+import type { Adapter, WalletName } from '@solana/wallet-adapter-base';
 import type { WalletAdapter } from '@saberhq/use-solana';
 
 const URLS: Record<'mainnet' | 'devnet' | 'localnet', string> = {
@@ -45,10 +45,12 @@ type PropsType = {
   dapp?: string; // base58 public key format
 };
 
+// TODO: this needs to be revisited...
 export type WalletType =
   | WalletContextState
   | AnchorWallet
   | WalletAdapter
+  | Adapter
   | null
   | undefined;
 
@@ -231,7 +233,7 @@ export const ApiProvider = ({ dapp, children }: PropsType): JSX.Element => {
   );
 
   const value: ValueType = {
-    wallet,
+    wallet: extractWalletAdapter(wallet),
     walletName: getWalletName(wallet),
     setWallet,
     network,


### PR DESCRIPTION
since use-solana wraps wallet adapter into one more adapter, we want to extract it

<img width="530" alt="Screenshot 2022-05-10 at 00 33 37" src="https://user-images.githubusercontent.com/5163918/167502266-35b36abb-83a2-4d09-b3a3-2989531070ec.png">

