### PR TITLE
fix: allow passing not only walletContext with adapter key, but also …

### DIFF
--- a/packages/dialect-react/utils/helpers.ts
+++ b/packages/dialect-react/utils/helpers.ts
@@ -55,6 +55,8 @@ export const extractWalletAdapter = (
   const isSaberUseSolana = Boolean(wallet?.adapter?.adapter);
   if (isSaberUseSolana) {
     return wallet.adapter.adapter;
+  } else if (wallet?.adapter) {
+    return wallet.adapter;
   }
-  return wallet.adapter;
+  return wallet;
 };


### PR DESCRIPTION
…walletAdapter itself