### PR TITLE
fix: do not render `useThreadMessages` before we have threadId

### DIFF
--- a/packages/dialect-react-ui/components/Notifications/screens/NotificationsList/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/screens/NotificationsList/index.tsx
@@ -6,6 +6,18 @@ import { useRoute } from '../../../common/providers/Router';
 import NoNotifications from './NoNotifications';
 import { Notification } from './Notification';
 
+const NotificationsListWrapper = () => {
+  const {
+    params: { threadId },
+  } = useRoute<{ threadId: ThreadId }>();
+
+  if (!threadId) {
+    return null;
+  }
+
+  return <NotificationsList />;
+};
+
 const NotificationsList = () => {
   const { notificationsDivider } = useTheme();
 
@@ -34,4 +46,4 @@ const NotificationsList = () => {
   );
 };
 
-export default NotificationsList;
+export default NotificationsListWrapper;


### PR DESCRIPTION
Fix the following error, when the Notifications widget opened but wallet is not yet 
![image](https://user-images.githubusercontent.com/2504771/177282459-e9b08939-80d8-469c-ad08-2d8c09925566.png)
