### PR TITLE
hotfix: save dialect auth token per wallet when using v0 addresses api

### DIFF
--- a/packages/dialect-react-sdk/CHANGELOG.md
+++ b/packages/dialect-react-sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+- hotfix: save dialect auth token per wallet when using v0 addresses api
+
+## [1.0.0-beta.6] - 2022-07-07
+
 - feature: add `useDapp` and `useDappAddresses` hooks to the `react-sdk`
 
 ## [1.0.0-beta.5] - 2022-06-30

--- a/packages/dialect-react-sdk/web2.api.ts
+++ b/packages/dialect-react-sdk/web2.api.ts
@@ -54,19 +54,28 @@ const generateToken = async (wallet: DialectWalletAdapter): Promise<string> => {
   return `${expirationTime}.${base64Signature}`;
 };
 
-const saveToken = (token: string) => {
+const saveToken = (token: string, wallet: DialectWalletAdapter) => {
   if (!window) return;
-  window.sessionStorage.setItem('token', token);
+  window.sessionStorage.setItem(
+    `dialect-auth-token-${wallet?.publicKey?.toBase58()}`,
+    token
+  );
 };
 
-export const removeToken = () => {
+export const removeToken = (wallet: DialectWalletAdapter) => {
   if (!window) return;
-  window.sessionStorage.removeItem('token');
+  window.sessionStorage.removeItem(
+    `dialect-auth-token-${wallet?.publicKey?.toBase58()}`
+  );
 };
 
-const getTokenFromStorage = (): string | undefined => {
+const getTokenFromStorage = (
+  wallet: DialectWalletAdapter
+): string | undefined => {
   if (!window) return;
-  const token = window.sessionStorage.getItem('token');
+  const token = window.sessionStorage.getItem(
+    `dialect-auth-token-${wallet?.publicKey?.toBase58()}`
+  );
 
   if (!token) return;
   return token;
@@ -90,11 +99,11 @@ export const fetchJSON = async (
     options?.method === 'PUT' ||
     options?.method === 'DELETE'
   ) {
-    let token = getTokenFromStorage();
+    let token = getTokenFromStorage(wallet);
 
     if (!token || isTokenExpired(token)) {
       token = await generateToken(wallet);
-      saveToken(token);
+      saveToken(token, wallet);
     }
 
     headers = {


### PR DESCRIPTION
Context: While QA'ing dashboard we found what if user change wallet after generating token for v0 then the wrong token will be used, so this change fixes it adding a prefix.

It would be cool to update addresses management to new sdk, but it's not that quick. 