### PR TITLE
fix: force width and height for togglers

### DIFF
--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: notif channel togglers and refactoring
 - fix: do not filter subscriptions for general broadcast
+- fix: toggle styles with using some css reset or tailwind forms
 
 ## [1.0.0-beta.30] - 2022-08-08
 

--- a/packages/dialect-react-ui/components/common/primitives.tsx
+++ b/packages/dialect-react-ui/components/common/primitives.tsx
@@ -201,7 +201,7 @@ export function Toggle({
     >
       <input
         type="checkbox"
-        className="dt-input dt-appearance-none dt-opacity-0 dt-w-0 dt-h-0"
+        className="dt-input dt-appearance-none dt-opacity-0 !dt-w-0 !dt-h-0"
         {...props}
         checked={checked}
         onChange={() => onChange?.(!checked)}


### PR DESCRIPTION
found that sometimes uses some css resets or tailwind form, which basically forces checkbox width to smth and it breaks our styling. The idea is to add important for togglers w/h
<img width="320" alt="Screenshot 2022-08-09 at 16 47 15" src="https://user-images.githubusercontent.com/5163918/183665544-3d78e230-3643-4d5c-84fa-3cc6fbe1b49e.png">