### PR TITLE
Feature/configurable telegram bot url

### DIFF
--- a/packages/dialect-react-sdk/CHANGELOG.md
+++ b/packages/dialect-react-sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+## [1.0.0-beta.29] - 2022-08-30
+
+- feature: support dapp-configured telegram bots
+
 ## [1.0.0-beta.28] - 2022-08-25
 
 - feature: expose package version

--- a/packages/dialect-react-sdk/hooks/useDapp.ts
+++ b/packages/dialect-react-sdk/hooks/useDapp.ts
@@ -15,9 +15,13 @@ interface UseDappValue {
 
 interface UseDappParams {
   refreshInterval?: number;
+  verified?: boolean;
 }
 
-function useDapp({ refreshInterval }: UseDappParams = EMPTY_OBJ): UseDappValue {
+function useDapp({
+  refreshInterval,
+  verified = true,
+}: UseDappParams = EMPTY_OBJ): UseDappValue {
   const { dapps } = useDialectSdk();
   const {
     info: { wallet },
@@ -30,7 +34,7 @@ function useDapp({ refreshInterval }: UseDappParams = EMPTY_OBJ): UseDappValue {
 
   const { data: dappsList = EMPTY_ARR } = useSWR(
     DAPPS_CACHE_KEY,
-    () => dapps.findAll({ verified: true }),
+    () => dapps.findAll({ verified }),
     {
       refreshInterval: 0,
       revalidateIfStale: false,

--- a/packages/dialect-react-sdk/package.json
+++ b/packages/dialect-react-sdk/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/dialectlabs/react"
   },
   "dependencies": {
-    "@dialectlabs/sdk": "0.7.1",
+    "@dialectlabs/sdk": "0.8.0",
     "nanoid": "^4.0.0",
     "swr": "^1.3.0"
   },

--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+## [1.0.0-beta.51] - 2022-08-30
+
+- feature: support dapp-configured telegram bots 
+
 ## [1.0.0-beta.50] - 2022-08-26
 
 - fix: polling for chat components

--- a/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Email.tsx
+++ b/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Email.tsx
@@ -74,7 +74,8 @@ const Email = () => {
 
   const createEmail = useCallback(async () => {
     try {
-      await createAddress({ value: email });
+      const address = await createAddress({ value: email });
+      await toggleSubscription({ enabled: true, address });
       setError(null);
     } catch (e) {
       setError(e as Error);

--- a/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Sms.tsx
+++ b/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Sms.tsx
@@ -70,7 +70,8 @@ const Sms = () => {
 
   const saveSmsNumber = async () => {
     try {
-      await createAddress({ value: smsNumber });
+      const address = await createAddress({ value: smsNumber });
+      await toggleSubscription({ enabled: true, address });
       setError(null);
     } catch (e) {
       setError(e as Error);

--- a/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Telegram.tsx
+++ b/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Telegram.tsx
@@ -3,11 +3,13 @@ import { useTheme } from '../../../common/providers/DialectThemeProvider';
 import clsx from 'clsx';
 import {
   AddressType,
+  useDapp,
+  useDialectDapp,
+  useDialectSdk,
   useNotificationChannel,
   useNotificationChannelDappSubscription,
-  useDialectSdk,
 } from '@dialectlabs/react-sdk';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { RightAdornment } from './RightAdorment';
 import { VerificationInput } from './VerificationInput';
 import { P } from '../../../common/preflighted';
@@ -41,6 +43,9 @@ const Telegram = () => {
     toggleSubscription,
     isToggling,
   } = useNotificationChannelDappSubscription({ addressType });
+
+  const { dapps } = useDapp({ verified: false });
+  const { dappAddress } = useDialectDapp();
 
   const { textStyles, colors } = useTheme();
 
@@ -114,10 +119,24 @@ const Telegram = () => {
     }
   };
 
-  const botURL =
+  const defaultBotUrl =
     environment === 'production'
-      ? 'https://telegram.me/DialectLabsBot'
-      : 'https://telegram.me/DialectLabsDevBot';
+      ? 'https://t.me/DialectLabsBot'
+      : 'https://t.me/DialectLabsDevBot';
+
+  const botURL = useMemo(() => {
+    if (!dappAddress) {
+      return defaultBotUrl;
+    }
+    const dapp = dapps[dappAddress.toBase58()];
+    if (!dapp) {
+      return defaultBotUrl;
+    }
+    if (!dapp.telegramUsername) {
+      return defaultBotUrl;
+    }
+    return `https://t.me/${dapp.telegramUsername}`;
+  }, [dappAddress, dapps, defaultBotUrl]);
 
   const isUserEditing =
     telegramAddress?.value !== telegramUsername && isTelegramSaved;

--- a/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Telegram.tsx
+++ b/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Telegram.tsx
@@ -118,10 +118,13 @@ const Telegram = () => {
     }
   };
 
+  const buildBotUrl = (botUsername: string) =>
+    `https://t.me/${botUsername}?start=${botUsername}`;
+
   const defaultBotUrl =
     environment === 'production'
-      ? 'https://t.me/DialectLabsBot'
-      : 'https://t.me/DialectLabsDevBot';
+      ? buildBotUrl('DialectLabsBot')
+      : buildBotUrl('DialectLabsDevBot');
 
   const botURL = useMemo(() => {
     if (!dappAddress) {
@@ -131,10 +134,7 @@ const Telegram = () => {
     if (!dapp) {
       return defaultBotUrl;
     }
-    if (!dapp.telegramUsername) {
-      return defaultBotUrl;
-    }
-    return `https://t.me/${dapp.telegramUsername}`;
+    return buildBotUrl(dapp.telegramUsername);
   }, [dappAddress, dapps, defaultBotUrl]);
 
   const isUserEditing =
@@ -166,8 +166,8 @@ const Telegram = () => {
                   {' '}
                   Get verification code by starting{' '}
                 </span>
-                <span className="dt-underline">this bot </span>
-                <span className="dt-opacity-50">with command: /start</span>
+                <span className="dt-underline">this bot</span>
+                <span className="dt-opacity-50"> with command: /start </span>
               </a>
               <span
                 onClick={deleteTelegram}

--- a/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Telegram.tsx
+++ b/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Telegram.tsx
@@ -86,8 +86,7 @@ const Telegram = () => {
   const saveTelegram = async () => {
     try {
       const value = telegramUsername.replace('@', '');
-      const address = await createAddress({ value });
-      await toggleSubscription({ enabled: true, address });
+      await createAddress({ value });
       setError(null);
     } catch (e) {
       setError(e as Error);

--- a/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Telegram.tsx
+++ b/packages/dialect-react-ui/components/Notifications/screens/NewSettings/Telegram.tsx
@@ -86,7 +86,8 @@ const Telegram = () => {
   const saveTelegram = async () => {
     try {
       const value = telegramUsername.replace('@', '');
-      await createAddress({ value });
+      const address = await createAddress({ value });
+      await toggleSubscription({ enabled: true, address });
       setError(null);
     } catch (e) {
       setError(e as Error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,10 +1403,10 @@
   dependencies:
     "@bonfida/spl-name-service" "^0.1.49"
 
-"@dialectlabs/sdk@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@dialectlabs/sdk/-/sdk-0.7.1.tgz#f87fdd7e731f26771c4a41a0bb0d7630b760891c"
-  integrity sha512-AEaVm8jHjJODf6hbVOBqFlwBOTEDlJ3cJjJXv3TVCINSkrcgwUXRu/Wc+h5FSj5w+0gmxy58hfun6DeHMa2Xzg==
+"@dialectlabs/sdk@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@dialectlabs/sdk/-/sdk-0.8.0.tgz#13a7be13d827b604e7715528716e657f4b889175"
+  integrity sha512-1E/eKLnwc9HPfXVUI2Xa1RJrkj2ID9yA0VHwml2TtMK1xwbpluIfLS864A9jcuXhLY9TVncK2YC1tvqiliArxQ==
   dependencies:
     "@dialectlabs/web3" "^0.3.2"
     "@project-serum/anchor" "0.23.0"


### PR DESCRIPTION
Feature scope:

1. Support creating and running dapp-configured telegram bot in data-service
2. Add telegram token configuration to dapp API in sdk
3. Use server-provided telegram username in notification modal
4. Bonus: deeplink to start button, there's no need to type /start now

Related PRs:

1. https://github.com/dialectlabs/sdk/pull/65
5. https://github.com/dialectlabs/data-service/pull/50

Will bump `@dialectlabs/sdk` version after PRs above are approved and merged