### PR TITLE
Feature/fix polling for chat

### DIFF
--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- fix: polling for chat components
+
 ## [1.0.0-beta.49] - 2022-08-25
 
 - feature: expose package version

--- a/packages/dialect-react-ui/components/Chat/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/index.tsx
@@ -21,9 +21,6 @@ type ChatType = 'inbox' | 'popup' | 'vertical-slider';
 
 interface InnerChatProps {
   dialectId: string;
-  type: ChatType;
-  wrapperClassName?: string;
-  contentWrapperClassName?: string;
 }
 
 function InnerChat({ dialectId }: InnerChatProps): JSX.Element {
@@ -61,6 +58,7 @@ interface ChatProps {
   contentWrapperClassName?: string;
   onChatClose?: () => void;
   onChatOpen?: () => void;
+  pollingInterval?: number;
 }
 
 export default function Chat({
@@ -68,6 +66,7 @@ export default function Chat({
   contentWrapperClassName,
   onChatOpen,
   onChatClose,
+  pollingInterval,
   ...props
 }: ChatProps) {
   const { dialectId, type } = props;
@@ -99,6 +98,7 @@ export default function Chat({
         type={type}
         onChatOpen={onChatOpen}
         onChatClose={onChatClose}
+        pollingInterval={pollingInterval}
       >
         <div
           className={clsx(
@@ -117,7 +117,10 @@ export default function Chat({
             )}
           >
             <WalletStatesWrapper header={defaultHeader}>
-              <ConnectionWrapper header={defaultHeader}>
+              <ConnectionWrapper
+                header={defaultHeader}
+                pollingInterval={pollingInterval}
+              >
                 <InnerChat {...props} />
               </ConnectionWrapper>
             </WalletStatesWrapper>

--- a/packages/dialect-react-ui/components/Chat/provider/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/provider/index.tsx
@@ -8,6 +8,7 @@ interface ChatContextValue {
   type: ChatType;
   onChatClose?: () => void;
   onChatOpen?: () => void;
+  pollingInterval?: number;
 }
 
 interface ChatProviderProps {
@@ -15,15 +16,23 @@ interface ChatProviderProps {
   type: ChatType;
   onChatClose?: () => void;
   onChatOpen?: () => void;
+  pollingInterval?: number;
 }
+
+const DEFAULT_POLLING_INTERVAL = 2000; // Value TBD
 
 export const ChatContext = createContext<ChatContextValue | null>(null);
 
 export const ChatProvider: FunctionComponent<ChatProviderProps> = ({
   children,
+  pollingInterval = DEFAULT_POLLING_INTERVAL,
   ...props
 }) => {
-  return <ChatContext.Provider value={props}>{children}</ChatContext.Provider>;
+  return (
+    <ChatContext.Provider value={{ ...props, pollingInterval }}>
+      {children}
+    </ChatContext.Provider>
+  );
 };
 
 export const useChatInternal = () => {

--- a/packages/dialect-react-ui/components/Chat/screens/CreateThreadPage/CreateThread.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/CreateThreadPage/CreateThread.tsx
@@ -226,9 +226,13 @@ export default function CreateThread({
             className="dt-mb-2"
             label={
               isOffChain ? (
-                <span className="dt-flex dt-items-center">💬  Off-chain</span>
+                <span className="dt-flex dt-items-center">
+                  💬&nbsp;&nbsp;Off-chain
+                </span>
               ) : (
-                <span className="dt-flex dt-items-center">⛓  On-chain</span>
+                <span className="dt-flex dt-items-center">
+                  ⛓&nbsp;&nbsp;On-chain
+                </span>
               )
             }
           >

--- a/packages/dialect-react-ui/components/Chat/screens/Main/ThreadsList/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/ThreadsList/index.tsx
@@ -13,6 +13,7 @@ import { useTheme } from '../../../../common/providers/DialectThemeProvider';
 import { useRoute } from '../../../../common/providers/Router';
 import MessagePreview from './MessagePreview';
 import { UI_VERSION } from '../../../../../version';
+import { useChatInternal } from '../../../provider';
 
 interface ThreadsListProps {
   onThreadClick?: (dialectAccount: Thread) => void;
@@ -22,8 +23,8 @@ const ThreadsList = ({ onThreadClick }: ThreadsListProps) => {
   const {
     params: { threadId },
   } = useRoute<{ threadId?: ThreadId }>();
-  const { threads } = useThreads();
-  // const threads = [];
+  const { pollingInterval } = useChatInternal();
+  const { threads } = useThreads({ refreshInterval: pollingInterval });
   const {
     info: { apiAvailability },
   } = useDialectSdk();

--- a/packages/dialect-react-ui/components/Chat/screens/ThreadPage/ThreadContent.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/ThreadPage/ThreadContent.tsx
@@ -26,21 +26,25 @@ type ThreadContentProps = {
 
 const ThreadContent = ({ threadId }: ThreadContentProps) => {
   const { current, navigate } = useRoute();
-  const { thread, isAdminable } = useThread({ findParams: { id: threadId } });
+  const { type, onChatOpen, onChatClose, dialectId, pollingInterval } =
+    useChatInternal();
+  const { thread, isAdminable } = useThread({
+    findParams: { id: threadId },
+    refreshInterval: pollingInterval,
+  });
   const {
     info: {
       solana: { dialectProgram },
     },
   } = useDialectSdk();
   const { icons, xPaddedText } = useTheme();
-  const { type, onChatOpen, onChatClose, dialectId } = useChatInternal();
   const { ui } = useDialectUiId(dialectId);
   const connection = dialectProgram?.provider.connection;
   const otherMemberPK =
     thread?.otherMembers[0] && thread.otherMembers[0].publicKey;
 
   // TODO: ! is unsafe
-  const { identity, loading } = useIdentity({ publicKey: otherMemberPK! });
+  const { identity } = useIdentity({ publicKey: otherMemberPK! });
 
   const isOnChain = thread?.backend === Backend.Solana;
 

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -166,7 +166,10 @@ export default function Notifications({
       >
         <Router>
           <WalletStatesWrapper header={fallbackHeader}>
-            <ConnectionWrapper header={fallbackHeader}>
+            <ConnectionWrapper
+              header={fallbackHeader}
+              pollingInterval={props.pollingInterval}
+            >
               <GatedWrapper gatedView={gatedView}>
                 <ThreadEncyprionWrapper otherMemberPK={dappAddress}>
                   <InnerNotifications {...props} />

--- a/packages/dialect-react-ui/components/NotificationsButton/index.tsx
+++ b/packages/dialect-react-ui/components/NotificationsButton/index.tsx
@@ -10,6 +10,8 @@ import type { Channel } from '../common/types';
 import IconButton from '../IconButton';
 import Notifications, { NotificationType } from '../Notifications';
 
+const DEFAULT_POLLING_FOR_NOTIFICATIONS = 15000; // 15 sec refresh default
+
 export type PropTypes = {
   dialectId: string;
   bellClassName?: string;
@@ -101,11 +103,16 @@ function WrappedNotificationsButton(props: PropTypes): JSX.Element {
 
 export default function NotificationsButton({
   channels = ['web3', 'telegram', 'sms', 'email'],
+  pollingInterval = DEFAULT_POLLING_FOR_NOTIFICATIONS,
   ...props
 }: PropTypes): JSX.Element {
   return (
     <div className="dialect">
-      <WrappedNotificationsButton channels={channels} {...props} />
+      <WrappedNotificationsButton
+        channels={channels}
+        pollingInterval={pollingInterval}
+        {...props}
+      />
     </div>
   );
 }

--- a/packages/dialect-react-ui/components/common/providers/DialectUiManagementProvider.tsx
+++ b/packages/dialect-react-ui/components/common/providers/DialectUiManagementProvider.tsx
@@ -1,6 +1,5 @@
 import React, {
   createContext,
-  FunctionComponent,
   useCallback,
   useContext,
   useEffect,

--- a/packages/dialect-react-ui/entities/wrappers/ConnectionWrapper.tsx
+++ b/packages/dialect-react-ui/entities/wrappers/ConnectionWrapper.tsx
@@ -1,17 +1,22 @@
 import { useDialectConnectionInfo, useThreads } from '@dialectlabs/react-sdk';
 import NoConnectionError from '../errors/ui/NoConnectionError';
+import type { ReactNode } from 'react';
 
 // Only renders children if connected to successfully some backend
 
 interface ConnectionWrapperProps {
   header?: JSX.Element | null;
-  children?: React.ReactNode;
+  pollingInterval?: number;
+  children?: ReactNode;
 }
 
 // FIXME: trigger some hook to check connection
 
 export default function ConnectionWrapper({
   header,
+  // fallback to a separate value, since this is more about the connection, rather than fetching functionality
+  // potentially can be a separate setting completely, TBD.
+  pollingInterval = 5000,
   children,
 }: ConnectionWrapperProps): JSX.Element {
   // TODO: take into account offline
@@ -29,8 +34,8 @@ export default function ConnectionWrapper({
   } = useDialectConnectionInfo();
 
   // FIXME: trigger some fetch from some of backends to get connection state
-  const { errorFetchingThreads } = useThreads({
-    refreshInterval: 5000,
+  useThreads({
+    refreshInterval: pollingInterval,
   });
 
   const someBackendConnected =

--- a/packages/dialect-react-ui/entities/wrappers/ConnectionWrapper.tsx
+++ b/packages/dialect-react-ui/entities/wrappers/ConnectionWrapper.tsx
@@ -3,7 +3,6 @@ import NoConnectionError from '../errors/ui/NoConnectionError';
 import type { ReactNode } from 'react';
 
 // Only renders children if connected to successfully some backend
-
 interface ConnectionWrapperProps {
   header?: JSX.Element | null;
   pollingInterval?: number;
@@ -12,11 +11,13 @@ interface ConnectionWrapperProps {
 
 // FIXME: trigger some hook to check connection
 
+const DEFAULT_CONNECTIVITY_POLLING_INTERVAL = 5000;
+
 export default function ConnectionWrapper({
   header,
   // fallback to a separate value, since this is more about the connection, rather than fetching functionality
   // potentially can be a separate setting completely, TBD.
-  pollingInterval = 5000,
+  pollingInterval = DEFAULT_CONNECTIVITY_POLLING_INTERVAL,
   children,
 }: ConnectionWrapperProps): JSX.Element {
   // TODO: take into account offline


### PR DESCRIPTION
Fixes non-existent polling in chat.

Values are arbitrary, 2s for general polling, 5s for connectivity (but might be even unnecessary, since we poll more often.
As an option, add some logic into calculating the proper polling interval for connectivity, something like:
```
if (DEFAULT_CONNECTIVITY_POLLING_INTERVAL > pollingInterval) {
 // use polling interval or don't poll at all
} else {
 // use the default, so that we know about connectivity issues early on
}
```

Thoughts?