### PR TITLE
Feature/unread across chats UI

### DIFF
--- a/examples/bottom-chat/pages/index.tsx
+++ b/examples/bottom-chat/pages/index.tsx
@@ -67,7 +67,7 @@ export const themeVariables: IncomingThemeVariables = {
     slider:
       'sm:border-t sm:border-l sm:border-r border-[#F0F0F0] shadow-lg shadow-neutral-300 sm:rounded-t-3xl',
     colors: {
-      primary: 'text-[#353535]',
+      textPrimary: 'text-[#353535]',
     },
     button: `${defaultVariables.light.button} border-none bg-[#B852DC]`,
     highlighted: `${defaultVariables.light.highlighted} bg-[#F6F6F6] border border-[#F0F0F0]`,

--- a/examples/chat/pages/index.tsx
+++ b/examples/chat/pages/index.tsx
@@ -6,17 +6,20 @@ import { CardinalTwitterIdentityResolver } from '@dialectlabs/identity-cardinal'
 import { DialectDappsIdentityResolver } from '@dialectlabs/identity-dialect-dapps';
 import { SNSIdentityResolver } from '@dialectlabs/identity-sns';
 import {
-  Backend, ChatButton,
+  Backend,
+  ChatButton,
   Config,
   defaultVariables,
   DialectContextProvider,
   DialectThemeProvider,
-  DialectUiManagementProvider, DialectWalletAdapter, IncomingThemeVariables
+  DialectUiManagementProvider,
+  DialectWalletAdapter,
+  IncomingThemeVariables,
 } from '@dialectlabs/react-ui';
 import {
   useConnection,
   useWallet,
-  WalletContextState
+  WalletContextState,
 } from '@solana/wallet-adapter-react';
 import Head from 'next/head';
 import { Wallet as WalletButton } from '../components/Wallet';
@@ -41,14 +44,14 @@ export const themeVariables: IncomingThemeVariables = {
     modal:
       'sm:border border-[#F0F0F0] shadow-lg shadow-neutral-300 sm:rounded-xl',
     colors: {
-      primary: 'text-[#353535]',
+      textPrimary: 'text-[#353535]',
     },
     button: `${defaultVariables.light.button} border-none bg-[#B852DC]`,
     highlighted: `${defaultVariables.light.highlighted} bg-[#F6F6F6] border border-[#F0F0F0]`,
     input: `${defaultVariables.light.input} border-b-[#59C29D] focus:ring-[#59C29D] text-[#59C29D]`,
     iconButton: `${defaultVariables.light.iconButton} hover:text-[#59C29D] hover:opacity-100`,
     avatar: `${defaultVariables.light.avatar} bg-[#F6F6F6]`,
-    messageBubble: `${defaultVariables.light.messageBubble} border-none bg-[#448EF7] text-white`,
+    messageBubble: `${defaultVariables.light.messageBubble} border-none bg-[#448EF7] text-black`,
     sendButton: `${defaultVariables.light.sendButton} bg-[#59C29D]`,
   },
 };

--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- feature: add unread messages indicator for chat components
+
 ## [1.0.0-beta.51] - 2022-08-30
 
 - feature: support dapp-configured telegram bots 

--- a/packages/dialect-react-ui/components/Broadcast/BroadcastForm.tsx
+++ b/packages/dialect-react-ui/components/Broadcast/BroadcastForm.tsx
@@ -195,7 +195,7 @@ function BroadcastForm({
       <Button
         onClick={sendBroadcastMessage}
         loading={isSending}
-        readOnly={isSubmitDisabled}
+        disabled={isSubmitDisabled}
       >
         {isSending ? 'Sending...' : 'Send'}
       </Button>

--- a/packages/dialect-react-ui/components/Broadcast/index.tsx
+++ b/packages/dialect-react-ui/components/Broadcast/index.tsx
@@ -5,8 +5,9 @@ import WalletStatesWrapper from '../../entities/wrappers/WalletStatesWrapper';
 import BroadcastForm from './BroadcastForm';
 import ConnectionWrapper from '../../entities/wrappers/ConnectionWrapper';
 import DashboardWrapper from '../../entities/wrappers/DashboardWrapper';
+import type { ComponentPropsWithoutRef } from 'react';
 
-const Wrapper = (props) => {
+const Wrapper = (props: ComponentPropsWithoutRef<'div'>) => {
   const { textStyles, colors } = useTheme();
   return (
     <div

--- a/packages/dialect-react-ui/components/Chat/MessageBubble.tsx
+++ b/packages/dialect-react-ui/components/Chat/MessageBubble.tsx
@@ -4,10 +4,10 @@ import Avatar from '../Avatar';
 import { ButtonLink, LinkifiedText } from '../common';
 import { useTheme } from '../common/providers/DialectThemeProvider';
 import MessageStatus from './MessageStatus';
-import type { Message } from '@dialectlabs/react-sdk';
+import type { LocalThreadMessage } from '@dialectlabs/react-sdk';
 import { formatTimestamp } from '../../utils/timeUtils';
 
-type MessageBubbleProps = Message & {
+type MessageBubbleProps = LocalThreadMessage & {
   isOnChain: boolean;
   isYou: boolean;
   isSending?: boolean;

--- a/packages/dialect-react-ui/components/Chat/provider/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/provider/index.tsx
@@ -19,7 +19,7 @@ interface ChatProviderProps {
   pollingInterval?: number;
 }
 
-const DEFAULT_POLLING_INTERVAL = 2000; // Value TBD
+export const DEFAULT_POLLING_INTERVAL = 2000;
 
 export const ChatContext = createContext<ChatContextValue | null>(null);
 

--- a/packages/dialect-react-ui/components/Chat/screens/Main/ThreadsList/MessagePreview.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/ThreadsList/MessagePreview.tsx
@@ -1,6 +1,6 @@
 import {
   Backend,
-  Message,
+  LocalThreadMessage,
   ThreadId,
   useDialectSdk,
   useThread as useThreadInternal,
@@ -13,7 +13,7 @@ import Avatar from '../../../../Avatar';
 import { useTheme } from '../../../../common/providers/DialectThemeProvider';
 import { DisplayAddress } from '../../../../DisplayAddress';
 import MessageStatus from '../../../MessageStatus';
-import { OnChainIndicator } from '../../../../common';
+import { OnChainIndicator, UnreadMessagesBadge } from '../../../../common';
 import { Encrypted } from '../../../../Icon';
 
 type PropsType = {
@@ -27,7 +27,7 @@ function FirstMessage({
   firstMessage,
   isEncrypted,
 }: {
-  firstMessage?: Message;
+  firstMessage?: LocalThreadMessage;
   isEncrypted: boolean;
 }) {
   const {
@@ -125,11 +125,7 @@ export default function MessagePreview({
               />
             )}
           </span>
-          {unreadCount > 0 && (
-            <div className="dt-mt-1 dt-min-w-[1.25rem] dt-h-[1.25rem] dt-bg-white dt-text-black dt-rounded-full dt-flex dt-items-center dt-justify-center">
-              {unreadCount}
-            </div>
-          )}
+          <UnreadMessagesBadge amount={unreadCount} className="dt-mt-1" />
         </div>
       </div>
     </div>

--- a/packages/dialect-react-ui/components/Chat/screens/Main/ThreadsList/MessagePreview.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/ThreadsList/MessagePreview.tsx
@@ -5,6 +5,7 @@ import {
   useDialectSdk,
   useThread as useThreadInternal,
   useThreadMessages,
+  useUnreadMessages,
 } from '@dialectlabs/react-sdk';
 import clsx from 'clsx';
 import { formatTimestamp } from '../../../../../utils/timeUtils';
@@ -70,6 +71,9 @@ export default function MessagePreview({
   // TODO: ensure there is no re-renders
   const { thread } = useThreadInternal({ findParams: { id: threadId } });
   const { messages } = useThreadMessages({ id: threadId });
+  const { unreadCount } = useUnreadMessages({
+    otherMembers: thread?.otherMembers.map((m) => m.publicKey) ?? [],
+  });
   const { colors } = useTheme();
   const [firstMessage] = messages ?? [];
   const connection = dialectProgram?.provider.connection;
@@ -110,7 +114,7 @@ export default function MessagePreview({
             isEncrypted={thread.encryptionEnabled}
           />
         </div>
-        <div className="dt-items-end dt-text-xs">
+        <div className="dt-flex dt-flex-col dt-items-end dt-text-xs">
           <span className="dt-opacity-30">
             {timestamp ? (
               timestamp
@@ -121,6 +125,11 @@ export default function MessagePreview({
               />
             )}
           </span>
+          {unreadCount > 0 && (
+            <div className="dt-mt-1 dt-min-w-[1.25rem] dt-h-[1.25rem] dt-bg-white dt-text-black dt-rounded-full dt-flex dt-items-center dt-justify-center">
+              {unreadCount}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
@@ -10,13 +10,17 @@ import { Route, Router, useRoute } from '../../../common/providers/Router';
 import { MainRouteName, RouteName, ThreadRouteName } from '../../constants';
 import { useDialectUiId } from '../../../common/providers/DialectUiManagementProvider';
 import { useIsomorphicLayoutEffect } from '../../../../hooks/useIsomorphicLayoutEffect';
+import { UnreadMessagesBadge } from '../../../common';
+import { useUnreadMessages } from '@dialectlabs/react-sdk';
 
 const Main = () => {
   const { navigate, current } = useRoute();
   const { type, onChatClose, onChatOpen, dialectId } = useChatInternal();
   const { ui } = useDialectUiId(dialectId);
   const [hideList, setHideList] = useState(false);
+  const { unreadCount } = useUnreadMessages();
   const inbox = type === 'inbox';
+  const bottomChat = type === 'vertical-slider';
 
   const { icons } = useTheme();
 
@@ -42,6 +46,8 @@ const Main = () => {
     [navigate]
   );
 
+  console.log(unreadCount);
+
   return (
     <Router initialRoute={MainRouteName.Thread}>
       <div className="dt-h-full dt-flex dt-flex-1 dt-justify-between dt-w-full">
@@ -61,7 +67,17 @@ const Main = () => {
             onHeaderClick={onChatOpen}
             isWindowOpen={ui?.open}
           >
-            <Header.Title>Messages</Header.Title>
+            <Header.Title>
+              <div className="dt-flex dt-items-center">
+                Messages{' '}
+                {!ui?.open && bottomChat && (
+                  <UnreadMessagesBadge
+                    amount={unreadCount}
+                    className="dt-ml-2 dt-mt-1"
+                  />
+                )}
+              </div>
+            </Header.Title>
             <Header.Icons>
               <Header.Icon
                 icon={<icons.compose />}

--- a/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/Main/index.tsx
@@ -46,8 +46,6 @@ const Main = () => {
     [navigate]
   );
 
-  console.log(unreadCount);
-
   return (
     <Router initialRoute={MainRouteName.Thread}>
       <div className="dt-h-full dt-flex dt-flex-1 dt-justify-between dt-w-full">

--- a/packages/dialect-react-ui/components/Chat/screens/ThreadPage/MessageInput.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/ThreadPage/MessageInput.tsx
@@ -19,7 +19,6 @@ type PropsType = {
 export default function MessageInput({
   text,
   setText,
-  error,
   setError,
   onSubmit,
   onEnterPress,
@@ -27,13 +26,6 @@ export default function MessageInput({
   inputDisabled,
 }: PropsType): JSX.Element {
   const { icons, textArea, sendButton } = useTheme();
-  // const { data } = useSWR(
-  //   connection && wallet ? ['/owner', wallet, connection] : null,
-  //   ownerFetcher
-  // );
-  // const balance: number | undefined = data?.lamports
-  //   ? data.lamports / 1e9
-  //   : undefined;
   return (
     <div>
       <div className="dt-flex dt-flex-col dt-pb-2 dt-mb-2">

--- a/packages/dialect-react-ui/components/ChatButton/index.tsx
+++ b/packages/dialect-react-ui/components/ChatButton/index.tsx
@@ -6,6 +6,9 @@ import Chat from '../Chat';
 import { useTheme } from '../common/providers/DialectThemeProvider';
 import { useDialectUiId } from '../common/providers/DialectUiManagementProvider';
 import IconButton from '../IconButton';
+import { useUnreadMessages } from '@dialectlabs/react-sdk';
+import { UnreadMessagesBadge } from '../common';
+import { DEFAULT_POLLING_INTERVAL } from '../Chat/provider';
 
 type PropTypes = {
   dialectId: string;
@@ -18,6 +21,9 @@ function WrappedChatButton(
   props: Omit<PropTypes, 'theme' | 'variables'>
 ): JSX.Element {
   const { ui, open, close } = useDialectUiId(props.dialectId);
+  const { unreadCount } = useUnreadMessages({
+    refreshInterval: props.pollingInterval ?? DEFAULT_POLLING_INTERVAL,
+  });
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const bellRef = useRef<HTMLButtonElement>(null);
@@ -32,16 +38,23 @@ function WrappedChatButton(
         colors.textPrimary
       )}
     >
-      <IconButton
-        ref={bellRef}
-        className={clsx(
-          'dt-flex dt-items-center dt-justify-center dt-rounded-full focus:dt-outline-none dt-shadow-md',
-          colors.bg,
-          bellButton
-        )}
-        icon={<icons.chat className={clsx('dt-w-6 dt-h-6 dt-rounded-full')} />}
-        onClick={ui?.open ? close : open}
-      ></IconButton>
+      <div className="dt-relative">
+        <IconButton
+          ref={bellRef}
+          className={clsx(
+            'dt-flex dt-items-center dt-justify-center dt-rounded-full focus:dt-outline-none dt-shadow-md',
+            colors.bg,
+            bellButton
+          )}
+          icon={
+            <icons.chat className={clsx('dt-w-6 dt-h-6 dt-rounded-full')} />
+          }
+          onClick={ui?.open ? close : open}
+        />
+        <div className="dt-absolute -dt-top-1 -dt-right-1">
+          <UnreadMessagesBadge amount={unreadCount} />
+        </div>
+      </div>
       <Transition
         className={modalWrapper}
         show={ui?.open ?? false}
@@ -60,7 +73,7 @@ function WrappedChatButton(
   );
 }
 
-export default function ChatButton({ ...props }: PropTypes): JSX.Element {
+export default function ChatButton(props: PropTypes): JSX.Element {
   return (
     <div className="dialect">
       <WrappedChatButton {...props} />

--- a/packages/dialect-react-ui/components/common/Section.tsx
+++ b/packages/dialect-react-ui/components/common/Section.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
 import clsx from 'clsx';
 import { useTheme } from './providers/DialectThemeProvider';
 import { Divider } from './primitives';
+import type { ReactNode } from 'react';
 
 export default function Section(props: {
-  title: React.ReactNode | string;
-  children: React.ReactNode;
+  title: ReactNode | string;
+  children: ReactNode;
   className?: string;
   defaultExpanded?: boolean;
 }) {

--- a/packages/dialect-react-ui/components/common/ToggleSection.tsx
+++ b/packages/dialect-react-ui/components/common/ToggleSection.tsx
@@ -1,17 +1,17 @@
-import React, { useEffect, useState } from 'react';
 import clsx from 'clsx';
+import type { ReactNode } from 'react';
 import { Toggle, ValueRow } from '../common';
 import { useTheme } from './providers/DialectThemeProvider';
 
 type PropsType = {
-  title: string | React.ReactNode;
+  title: string | ReactNode;
   className?: string;
   checked: boolean;
   disabled?: boolean;
   hideToggle?: boolean;
   noBorder?: boolean;
   onChange?: (nextValue: boolean) => void;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 export default function ToggleSection({

--- a/packages/dialect-react-ui/components/common/UnreadMessagesBadge.tsx
+++ b/packages/dialect-react-ui/components/common/UnreadMessagesBadge.tsx
@@ -7,13 +7,14 @@ interface Props {
 }
 
 export default function UnreadMessagesBadge({ amount, className }: Props) {
-  const { textStyles } = useTheme();
+  const { textStyles, colors } = useTheme();
 
   return amount > 0 ? (
     <div
       className={clsx(
-        'dt-min-w-[1.25rem] dt-h-[1.25rem] dt-bg-white dt-text-black dt-rounded-full dt-flex dt-items-center dt-justify-center',
+        'dt-w-5 dt-h-5 dt-rounded-full dt-flex dt-items-center dt-justify-center',
         textStyles.small,
+        colors.notificationBadgeColor,
         className
       )}
     >

--- a/packages/dialect-react-ui/components/common/UnreadMessagesBadge.tsx
+++ b/packages/dialect-react-ui/components/common/UnreadMessagesBadge.tsx
@@ -1,0 +1,23 @@
+import { useTheme } from './providers/DialectThemeProvider';
+import clsx from 'clsx';
+
+interface Props {
+  amount: number;
+  className?: string;
+}
+
+export default function UnreadMessagesBadge({ amount, className }: Props) {
+  const { textStyles } = useTheme();
+
+  return amount > 0 ? (
+    <div
+      className={clsx(
+        'dt-min-w-[1.25rem] dt-h-[1.25rem] dt-bg-white dt-text-black dt-rounded-full dt-flex dt-items-center dt-justify-center',
+        textStyles.small,
+        className
+      )}
+    >
+      {amount}
+    </div>
+  ) : null;
+}

--- a/packages/dialect-react-ui/components/common/index.ts
+++ b/packages/dialect-react-ui/components/common/index.ts
@@ -5,3 +5,4 @@ export { default as LinkifiedText } from './LinkifiedText';
 export { default as ToggleSection } from './ToggleSection';
 export { default as Section } from './Section';
 export { default as OnChainIndicator } from './OnChainIndicator';
+export { default as UnreadMessagesBadge } from './UnreadMessagesBadge';

--- a/packages/dialect-react-ui/components/common/primitives.tsx
+++ b/packages/dialect-react-ui/components/common/primitives.tsx
@@ -109,7 +109,6 @@ export function Button(props: {
   className?: string;
   onClick?: () => void;
   disabled?: boolean;
-  readOnly?: boolean;
   loading?: boolean;
   children: React.ReactNode;
 }): JSX.Element {
@@ -122,12 +121,11 @@ export function Button(props: {
       className={clsx(
         'dt-min-w-120 dt-px-4 dt-py-2 dt-rounded-lg dt-flex dt-flex-row dt-items-center dt-justify-center',
         textStyles.buttonText,
-        props.disabled || props.readOnly ? disabledButton : defaultClassName,
+        props.disabled ? disabledButton : defaultClassName,
         props.loading && loadingClassName,
         props.className
       )}
       onClick={props.onClick}
-      readOnly={props.readOnly}
       disabled={props.loading || props.disabled}
     >
       {!props.loading ? props.children : <Loader />}

--- a/packages/dialect-react-ui/components/common/providers/DialectThemeProvider.tsx
+++ b/packages/dialect-react-ui/components/common/providers/DialectThemeProvider.tsx
@@ -203,7 +203,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> &
       // circle in toggle
       toggleThumb: 'dt-bg-[#1F1F1F]',
       // notification badge
-      notificationBadgeColor: 'dt-bg-red-500',
+      notificationBadgeColor: 'dt-bg-[#6F2AFF] dt-text-white',
       // input label
       label: 'dt-text-black/60',
     },
@@ -256,8 +256,8 @@ export const defaultVariables: Record<ThemeType, ThemeValues> &
       'dt-text-sm dt-h-[3.75rem] dt-text-white dt-bg-subtle-night dt-px-3 dt-py-2.5 dt-border-2 dt-border-neutral-600 dt-rounded-lg focus-within:dt-bg-black  focus-within:dt-border-white focus:dt-outline-none dt-rounded-2xl',
     textArea:
       'dt-text-sm dt-text-neutral-800 dt-bg-white dt-border dt-rounded-2xl dt-px-2 dt-py-1 dt-border-neutral-300 dt-placeholder-neutral-400 dt-pr-10 dt-outline-none disabled:dt-text-neutral-800/50',
-    messageBubble: 'dt-text-black dt-px-4 dt-py-2 dt-rounded-2xl dt-text-white',
-    message: 'dt-bg-transparent dt-border dt-border-neutral-300 ',
+    messageBubble: 'dt-text-black dt-px-4 dt-py-2 dt-rounded-2xl dt-text-black',
+    message: 'dt-bg-transparent dt-border dt-border-neutral-300',
     otherMessage: 'dt-bg-neutral-100',
     messageOnChain: 'dt-bg-[#6F2AFF]',
     otherMessageOnChain: 'dt-bg-neutral-100',
@@ -305,7 +305,7 @@ export const defaultVariables: Record<ThemeType, ThemeValues> &
       toggleBackground: 'dt-bg-white/60',
       toggleBackgroundActive: 'dt-bg-[#528E5B]',
       toggleThumb: 'dt-bg-[#1F1F1F]',
-      notificationBadgeColor: 'dt-bg-red-500',
+      notificationBadgeColor: 'dt-bg-[#6F2AFF] dt-text-white',
       label: 'dt-text-white/60',
     },
     textStyles: {

--- a/packages/dialect-react-ui/entities/LoadingThread.tsx
+++ b/packages/dialect-react-ui/entities/LoadingThread.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { Centered, Loader } from '../components/common';
-import { H3, P } from '../components/common/preflighted';
+import { H3 } from '../components/common/preflighted';
 import { useTheme } from '../components/common/providers/DialectThemeProvider';
 
 const LoadingThread = () => {

--- a/packages/dialect-react-ui/utils/deepMerge.ts
+++ b/packages/dialect-react-ui/utils/deepMerge.ts
@@ -13,11 +13,13 @@ export function isObject(item: unknown) {
  * Deep merge two objects.
  * @param target
  * @param ...sources
+ *
+ * TODO: `any` isn't great, ideally we describe these with generics
  */
 export default function deepMerge(
-  target: object,
-  ...sources: object[]
-): object {
+  target: Record<any, any>,
+  ...sources: Record<any, any>[]
+): Record<any, any> {
   if (!sources.length) return target;
   const source = sources.shift();
 


### PR DESCRIPTION
Adds an indicator of unread message for chat components: Inbox, BottomChat, ChatButton. 

Also, some minor types cleanup in order to not see any type errors during build.

## BottomChat
### Closed
<img width="552" alt="Screen Shot 2022-08-31 at 16 52 05" src="https://user-images.githubusercontent.com/8060965/187694331-fddf13e1-c26e-4105-a695-1683344f87a6.png">

### Open
<img width="552" alt="Screen Shot 2022-08-31 at 16 52 12" src="https://user-images.githubusercontent.com/8060965/187694492-bf27c43f-b361-4cc5-a4b7-528786c734f7.png">

## ChatButton
<img width="552" alt="Screen Shot 2022-08-31 at 16 44 52" src="https://user-images.githubusercontent.com/8060965/187694580-98b715d5-6dce-4661-9b10-0dc624072581.png">

## Inbox
<img width="552" alt="Screen Shot 2022-08-31 at 16 52 37" src="https://user-images.githubusercontent.com/8060965/187694689-c9aa906c-8ab3-416a-9d51-fcb1b488d10a.png">


