### PR TITLE
(core-631) fix: long message shrinks thread list

### DIFF
--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - remove Broadcast component
+- fix: make long messages don't shrink thread list column
 
 ## [1.1.0-beta.7] - 2022-11-11
 

--- a/packages/dialect-react-ui/components/Chat/MessageBubble.tsx
+++ b/packages/dialect-react-ui/components/Chat/MessageBubble.tsx
@@ -46,7 +46,7 @@ export default function MessageBubble({
         isYou && 'dt-ml-10 dt-justify-end'
       )}
     >
-      <div className="dt-flex dt-flex-col">
+      <div className="dt-flex dt-min-w-0 dt-flex-col">
         <div
           className={clsx(
             'dt-flex dt-flex-row',

--- a/packages/dialect-react-ui/components/Chat/screens/ThreadPage/ThreadContent.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/ThreadPage/ThreadContent.tsx
@@ -85,8 +85,8 @@ const ThreadContent = ({ threadId }: ThreadContentProps) => {
   }
 
   return (
-    <div className="dt-h-full dt-flex dt-flex-1 dt-min-w-[0px] dt-justify-between dt-w-full">
-      <div className="dt-flex dt-flex-col dt-flex-1 dt-min-w-[0px]">
+    <div className="dt-h-full dt-flex dt-flex-1 dt-min-w-0 dt-justify-between dt-w-full">
+      <div className="dt-flex dt-flex-col dt-flex-1 dt-min-w-0">
         {/* ↑ The min-width: 0 is used to prevent the column from overflow the container. Why: https://makandracards.com/makandra/66994-css-flex-and-min-width */}
         <Header
           type={type}

--- a/packages/dialect-react-ui/components/Chat/screens/ThreadPage/ThreadContent.tsx
+++ b/packages/dialect-react-ui/components/Chat/screens/ThreadPage/ThreadContent.tsx
@@ -85,8 +85,9 @@ const ThreadContent = ({ threadId }: ThreadContentProps) => {
   }
 
   return (
-    <div className="dt-h-full dt-flex dt-flex-1 dt-justify-between dt-w-full">
+    <div className="dt-h-full dt-flex dt-flex-1 dt-min-w-[0px] dt-justify-between dt-w-full">
       <div className="dt-flex dt-flex-col dt-flex-1 dt-min-w-[0px]">
+        {/* ↑ The min-width: 0 is used to prevent the column from overflow the container. Why: https://makandracards.com/makandra/66994-css-flex-and-min-width */}
         <Header
           type={type}
           onClose={onChatClose}


### PR DESCRIPTION
Before:
sent
<img width="552" alt="Screenshot 2022-11-17 at 17 49 49" src="https://user-images.githubusercontent.com/2504771/202463855-77041e67-a74b-4dc0-9626-7c1611b0d2dd.png">
in message input
<img width="552" alt="Screenshot 2022-11-17 at 17 50 23" src="https://user-images.githubusercontent.com/2504771/202463874-d62e5ceb-022a-48e0-ace9-d48682b047f4.png">

After:
sent
<img width="552" alt="Screenshot 2022-11-17 at 17 49 52" src="https://user-images.githubusercontent.com/2504771/202463975-50d2b516-8156-4b39-9169-526f4c29ac73.png">
in message input
<img width="552" alt="Screenshot 2022-11-17 at 17 50 21" src="https://user-images.githubusercontent.com/2504771/202464020-63a2febf-3dc5-4fe9-b025-1caf262d34ca.png">