### PR TITLE
feat: add ability to inject custom components into channels (both rem…

### DIFF
--- a/examples/notifications-solana/package.json
+++ b/examples/notifications-solana/package.json
@@ -13,7 +13,7 @@
     "@babel/runtime": "^7.16.7",
     "@dialectlabs/identity-dialect-dapps": "^1.0.0",
     "@dialectlabs/react-sdk-blockchain-solana": "^1.0.0-beta.4",
-    "@dialectlabs/react-ui": "^1.1.0-beta.12",
+    "@dialectlabs/react-ui": "^1.1.0-beta.14",
     "@solana/wallet-adapter-base": "^0.9.18",
     "@solana/wallet-adapter-react": "^0.15.24",
     "@solana/wallet-adapter-react-ui": "^0.9.22",

--- a/examples/notifications-solana/pages/index.tsx
+++ b/examples/notifications-solana/pages/index.tsx
@@ -116,7 +116,7 @@ export default function Home(): JSX.Element {
 
   const dialectConfig = useMemo((): ConfigProps => {
     return {
-      environment: 'development',
+      environment: 'production',
       dialectCloud: {
         tokenStore: 'local-storage',
       },

--- a/examples/notifications-solana/pages/index.tsx
+++ b/examples/notifications-solana/pages/index.tsx
@@ -66,8 +66,12 @@ function AuthedHome() {
             notifications={[
               {
                 name: 'Welcome Message',
-                detail:
-                  'Welcome message that is sent on first subscription',
+                detail: 'Welcome message that is sent on first subscription',
+                renderAdditional: () => (
+                  <div className="text-xs text-neutral-400">
+                    Additional information about the welcome message
+                  </div>
+                ),
               },
             ]}
             pollingInterval={15000}

--- a/packages/dialect-react-ui/CHANGELOG.md
+++ b/packages/dialect-react-ui/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [UNRELEASED]
 
+- feat: adds `renderAdditional` render property for `NotificationType` type which allows to render custom content in notification settings
+- feat: adds `remoteNotificationExtensions` prop that adds custom content to remote notifications
+
 ## [1.1.0-beta.13]
 
 - fix: broken dashboard dapp register link fixed

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -6,7 +6,7 @@ import {
   useThread,
 } from '@dialectlabs/react-sdk';
 import clsx from 'clsx';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import LoadingThread from '../../entities/LoadingThread';
 import ConnectionWrapper from '../../entities/wrappers/ConnectionWrapper';
 import ThreadEncyprionWrapper from '../../entities/wrappers/ThreadEncryptionWrapper';
@@ -23,12 +23,19 @@ import Settings from './screens/Settings';
 export type NotificationType = {
   name: string;
   detail?: string;
+  renderAdditional?: (state?: boolean) => ReactNode;
+};
+
+export type RemoteNotificationExtension = {
+  humanReadableId: string;
+  renderAdditional?: (state?: boolean) => ReactNode;
 };
 
 interface NotificationsProps {
   dappAddress: AccountAddress;
   onModalClose: () => void;
   notifications?: NotificationType[];
+  remoteNotificationExtensions?: RemoteNotificationExtension[];
   channels?: Channel[];
   onBackClick?: () => void;
   gatedView?: string | JSX.Element;
@@ -46,6 +53,7 @@ function InnerNotifications({
   notifications,
   settingsOnly,
   pollingInterval,
+  remoteNotificationExtensions,
 }: NotificationsProps): JSX.Element {
   const { thread, isFetchingThread } = useThread({
     findParams: { otherMembers: [dappAddress] },
@@ -140,6 +148,7 @@ function InnerNotifications({
                 dappAddress={dappAddress}
                 channels={channels || []}
                 notifications={notifications}
+                remoteNotificationExtensions={remoteNotificationExtensions}
               />
             </Route>
             <Route name={RouteName.Thread}>

--- a/packages/dialect-react-ui/components/Notifications/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/index.tsx
@@ -23,12 +23,12 @@ import Settings from './screens/Settings';
 export type NotificationType = {
   name: string;
   detail?: string;
-  renderAdditional?: (state?: boolean) => ReactNode;
+  renderAdditional?: () => ReactNode;
 };
 
 export type RemoteNotificationExtension = {
   humanReadableId: string;
-  renderAdditional?: (state?: boolean) => ReactNode;
+  renderAdditional?: (state: boolean) => ReactNode;
 };
 
 interface NotificationsProps {

--- a/packages/dialect-react-ui/components/Notifications/screens/Settings/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/screens/Settings/index.tsx
@@ -17,15 +17,29 @@ import Sms from '../NewSettings/Sms';
 import Telegram from '../NewSettings/Telegram';
 import Wallet from '../NewSettings/Wallet';
 
-interface RenderNotificationTypeParams {
+interface LocalRenderNotificationTypeParams {
   name: string;
   detail?: string;
   id?: string;
   enabled?: boolean;
-  type: 'local' | 'remote';
-  onToggle?: (value: boolean) => void;
-  renderAdditional?: (state?: boolean) => ReactNode;
+  type: 'local';
+  onToggle?: unknown;
+  renderAdditional?: () => ReactNode;
 }
+
+interface RemoteRenderNotificationTypeParams {
+  name: string;
+  detail?: string;
+  id?: string;
+  enabled?: boolean;
+  type: 'remote';
+  onToggle?: (value: boolean) => void;
+  renderAdditional?: (state: boolean) => ReactNode;
+}
+
+type RenderNotificationTypeParams =
+  | LocalRenderNotificationTypeParams
+  | RemoteRenderNotificationTypeParams;
 
 interface SettingsProps {
   dappAddress: AccountAddress;
@@ -65,7 +79,7 @@ export const NotificationToggle = ({
       )}
 
       {renderAdditional &&
-        renderAdditional(type === 'remote' ? enabled : undefined)}
+        (type === 'remote' ? renderAdditional(enabled) : renderAdditional())}
     </div>
   );
 };

--- a/packages/dialect-react-ui/components/Notifications/screens/Settings/index.tsx
+++ b/packages/dialect-react-ui/components/Notifications/screens/Settings/index.tsx
@@ -4,8 +4,8 @@ import {
   useNotificationSubscriptions,
 } from '@dialectlabs/react-sdk';
 import clsx from 'clsx';
-import { useCallback } from 'react';
-import type { NotificationType } from '../..';
+import { ReactNode, useCallback } from 'react';
+import type { RemoteNotificationExtension, NotificationType } from '../..';
 import { Divider, Footer, Toggle, ValueRow } from '../../../common';
 import { A, P } from '../../../common/preflighted';
 import { useTheme } from '../../../common/providers/DialectThemeProvider';
@@ -24,12 +24,14 @@ interface RenderNotificationTypeParams {
   enabled?: boolean;
   type: 'local' | 'remote';
   onToggle?: (value: boolean) => void;
+  renderAdditional?: (state?: boolean) => ReactNode;
 }
 
 interface SettingsProps {
   dappAddress: AccountAddress;
   channels: Channel[];
   notifications?: NotificationType[];
+  remoteNotificationExtensions?: RemoteNotificationExtension[];
 }
 
 export const NotificationToggle = ({
@@ -39,6 +41,7 @@ export const NotificationToggle = ({
   enabled = true,
   onToggle,
   type,
+  renderAdditional,
 }: RenderNotificationTypeParams) => {
   const { highlighted, colors, textStyles } = useTheme();
   return (
@@ -60,6 +63,9 @@ export const NotificationToggle = ({
           {detail}
         </P>
       )}
+
+      {renderAdditional &&
+        renderAdditional(type === 'remote' ? enabled : undefined)}
     </div>
   );
 };
@@ -68,6 +74,7 @@ function Settings({
   dappAddress,
   channels,
   notifications: notificationsTypes,
+  remoteNotificationExtensions,
 }: SettingsProps) {
   const { textStyles, xPaddedText } = useTheme();
   const {
@@ -139,6 +146,12 @@ function Settings({
                   enabled={subscription.config.enabled}
                   type="remote"
                   detail={notificationType.trigger}
+                  renderAdditional={
+                    remoteNotificationExtensions?.find(
+                      (ext) =>
+                        ext.humanReadableId === notificationType.humanReadableId
+                    )?.renderAdditional
+                  }
                   onToggle={(value) => {
                     if (isUpdating) return;
                     updateNotificationSubscription({

--- a/packages/dialect-react-ui/components/NotificationsButton/index.tsx
+++ b/packages/dialect-react-ui/components/NotificationsButton/index.tsx
@@ -7,7 +7,10 @@ import { useTheme } from '../common/providers/DialectThemeProvider';
 import { useDialectUiId } from '../common/providers/DialectUiManagementProvider';
 import type { Channel } from '../common/types';
 import IconButton from '../IconButton';
-import type { NotificationType } from '../Notifications';
+import type {
+  NotificationType,
+  RemoteNotificationExtension,
+} from '../Notifications';
 import NotificationsModal from '../NotificationsModal';
 
 const DEFAULT_POLLING_FOR_NOTIFICATIONS = 15000; // 15 sec refresh default
@@ -20,6 +23,7 @@ export type PropTypes = {
   notifications?: NotificationType[];
   gatedView?: string | JSX.Element;
   channels?: Channel[];
+  remoteNotificationExtensions?: RemoteNotificationExtension[];
   onBackClick?: () => void;
   pollingInterval?: number;
   Component?: (props: any) => JSX.Element;

--- a/packages/dialect-react-ui/components/NotificationsModal/index.tsx
+++ b/packages/dialect-react-ui/components/NotificationsModal/index.tsx
@@ -2,7 +2,10 @@ import { useEffect, forwardRef } from 'react';
 import { Transition } from '@headlessui/react';
 import { useDialectUiId } from '../common/providers/DialectUiManagementProvider';
 import type { Channel } from '../common/types';
-import Notifications, { NotificationType } from '../Notifications';
+import Notifications, {
+  NotificationType,
+  RemoteNotificationExtension,
+} from '../Notifications';
 import {
   ThemeAnimations,
   useTheme,
@@ -22,6 +25,7 @@ interface NotificationsModalProps {
   dialectId: string;
 
   notifications?: NotificationType[];
+  remoteNotificationExtensions?: RemoteNotificationExtension[];
   channels?: Channel[];
   gatedView?: string | JSX.Element;
   pollingInterval?: number;

--- a/packages/dialect-react-ui/package.json
+++ b/packages/dialect-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dialectlabs/react-ui",
-  "version": "1.1.0-beta.13",
+  "version": "1.1.0-beta.14",
   "description": "Dialect's react UI components",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
…ote and local)

Adds a `renderAdditional` property to `NotificationType` type and a new `remoteNotificationExtension` prop that would find the remote notification by matching the `humanReadableId` (TBD, needs to be clarified how unique is this) and pass down `renderAdditional` property.

<img width="500" alt="Screenshot 2023-06-24 at 19 03 32" src="https://github.com/dialectlabs/react/assets/8060965/a48b5d04-d71b-4d78-b242-d034c5ea9e36">
