### PR TITLE
Feat: Add optional custom notification ui

### DIFF
--- a/packages/react-sdk-blockchain-solana/src/context.tsx
+++ b/packages/react-sdk-blockchain-solana/src/context.tsx
@@ -16,6 +16,7 @@ export type Props = {
   config?: ConfigProps;
   customWalletAdapter?: DialectSolanaWalletAdapter;
   children: React.ReactNode;
+  customNotificationsUi?: React.ReactNode;
 };
 
 export interface DialectSolanaWalletAdapter {

--- a/packages/react-sdk/src/context/DialectContext/index.tsx
+++ b/packages/react-sdk/src/context/DialectContext/index.tsx
@@ -10,6 +10,7 @@ import { DialectSdk } from './Sdk';
 
 interface DialectContextValue {
   dappAddress: string;
+  customNotificationsUi?: React.ReactNode;
 }
 
 export const DialectContext = React.createContext<DialectContextValue>(
@@ -22,6 +23,7 @@ export type DialectContextProviderProps<ChainSdk extends BlockchainSdk> = {
   blockchainSdkFactory?: BlockchainSdkFactory<ChainSdk> | null;
   // gate?: Gate;
   children: React.ReactNode;
+  customNotificationsUi?: React.ReactNode;
 };
 
 export const useDialectContext = () => {
@@ -30,10 +32,16 @@ export const useDialectContext = () => {
 
 export const DialectContextProvider: React.FC<
   DialectContextProviderProps<BlockchainSdk>
-> = ({ config, blockchainSdkFactory, children, dappAddress }) => {
+> = ({
+  config,
+  blockchainSdkFactory,
+  children,
+  dappAddress,
+  customNotificationsUi,
+}) => {
   return (
     <SWRConfig>
-      <DialectContext.Provider value={{ dappAddress }}>
+      <DialectContext.Provider value={{ dappAddress, customNotificationsUi }}>
         <DialectSdk.Provider initialState={{ config, blockchainSdkFactory }}>
           {/* <DialectGate.Provider initialState={gate}> */}
           <LocalMessages.Provider>{children}</LocalMessages.Provider>

--- a/packages/react-ui/src/ui/notifications/Settings/Settings.tsx
+++ b/packages/react-ui/src/ui/notifications/Settings/Settings.tsx
@@ -14,7 +14,7 @@ import { SettingsLoading } from './SettingsLoading';
 import { TosAndPrivacy } from './TosAndPrivacy';
 
 export const Settings = () => {
-  const { dappAddress } = useDialectContext();
+  const { dappAddress, customNotificationsUi } = useDialectContext();
 
   const subscription = useNotificationChannelDappSubscription({
     addressType: AddressType.Wallet,
@@ -40,6 +40,7 @@ export const Settings = () => {
       <div className="dt-px-4">
         <NotificationTypes />
       </div>
+      {customNotificationsUi}
       <div className="dt-flex-1" />
       <div
         className={clsx(


### PR DESCRIPTION
This pull requests adds functionality to pass a custom UI component to be gated behind the settings section of the Dialect notifications dialog. 