### PR TITLE
Remove top banner from notifications-solana example

### DIFF
--- a/examples/notifications-solana/src/app/page.tsx
+++ b/examples/notifications-solana/src/app/page.tsx
@@ -13,11 +13,6 @@ export default function Home() {
   const [theme, setTheme] = useState<ThemeType>(getInitialTheme());
   return (
     <div className="flex min-h-screen flex-col">
-      <div className="bg-[#FEF9C2] px-8 py-3 text-center text-[15px] text-[#733E0A]">
-        ⚠️ Dialect is sunsetting its Alerts, Blockchain Links, Markets and
-        Positions products. If you are using these products you will need to
-        find alternative solutions.
-      </div>
       <div className="flex flex-1 flex-col px-8 py-5">
         <header className="flex items-center justify-between gap-3">
           <NoSSR>


### PR DESCRIPTION
Takes the top banner off the example app for now. A follow-up PR restores it once it's finalized. No other changes from #240 are affected.